### PR TITLE
chore: fix state tests

### DIFF
--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -17,6 +17,7 @@ package modprovider
 import (
 	"fmt"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -42,8 +43,13 @@ func NewModuleComponentResource(
 		return nil, fmt.Errorf("RegisterComponentResource failed: %w", err)
 	}
 
+	tt, err := tokens.ParseTypeToken(t)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid type token: %q", t)
+	}
+
 	go func() {
-		_, err := newModuleStateResource(ctx, Name(), pulumi.Parent(&component))
+		_, err := newModuleStateResource(ctx, tt.Package().String(), pulumi.Parent(&component))
 		contract.AssertNoErrorf(err, "newModuleStateResource failed")
 	}()
 

--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -43,6 +43,7 @@ type server struct {
 	hostClient         *provider.HostClient
 	stateStore         moduleStateStore
 	moduleStateHandler *moduleStateHandler
+	packageName        string
 }
 
 func (s *server) Parameterize(
@@ -59,6 +60,8 @@ func (s *server) Parameterize(
 	if err != nil {
 		return nil, fmt.Errorf("error while inferring package and resource name for %s: %w", pargs.TFModuleSource, err)
 	}
+
+	s.packageName = packageName
 
 	return &pulumirpc.ParameterizeResponse{
 		Name:    packageName,
@@ -174,7 +177,7 @@ func (rps *server) Check(
 	req *pulumirpc.CheckRequest,
 ) (*pulumirpc.CheckResponse, error) {
 	switch req.GetType() {
-	case fmt.Sprintf("%s:index:%s", Name(), moduleStateTypeName):
+	case fmt.Sprintf("%s:index:%s", rps.packageName, moduleStateTypeName):
 		return rps.moduleStateHandler.Check(ctx, req)
 	default:
 		return nil, fmt.Errorf("Type %q is not supported yet", req.GetType())
@@ -186,7 +189,7 @@ func (rps *server) Diff(
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
 	switch req.GetType() {
-	case fmt.Sprintf("%s:index:%s", Name(), moduleStateTypeName):
+	case fmt.Sprintf("%s:index:%s", rps.packageName, moduleStateTypeName):
 		return rps.moduleStateHandler.Diff(ctx, req)
 	default:
 		return nil, fmt.Errorf("Type %q is not supported yet", req.GetType())
@@ -198,7 +201,7 @@ func (rps *server) Create(
 	req *pulumirpc.CreateRequest,
 ) (*pulumirpc.CreateResponse, error) {
 	switch req.GetType() {
-	case fmt.Sprintf("%s:index:%s", Name(), moduleStateTypeName):
+	case fmt.Sprintf("%s:index:%s", rps.packageName, moduleStateTypeName):
 		return rps.moduleStateHandler.Create(ctx, req)
 	default:
 		return nil, fmt.Errorf("Type %q is not supported yet", req.GetType())
@@ -210,7 +213,7 @@ func (rps *server) Update(
 	req *pulumirpc.UpdateRequest,
 ) (*pulumirpc.UpdateResponse, error) {
 	switch req.GetType() {
-	case fmt.Sprintf("%s:index:%s", Name(), moduleStateTypeName):
+	case fmt.Sprintf("%s:index:%s", rps.packageName, moduleStateTypeName):
 		return rps.moduleStateHandler.Update(ctx, req)
 	default:
 		return nil, fmt.Errorf("Type %q is not supported yet", req.GetType())
@@ -222,7 +225,7 @@ func (rps *server) Delete(
 	req *pulumirpc.DeleteRequest,
 ) (*emptypb.Empty, error) {
 	switch req.GetType() {
-	case fmt.Sprintf("%s:index:%s", Name(), moduleStateTypeName):
+	case fmt.Sprintf("%s:index:%s", rps.packageName, moduleStateTypeName):
 		return rps.moduleStateHandler.Delete(ctx, req)
 	default:
 		return nil, fmt.Errorf("Type %q is not supported yet", req.GetType())

--- a/pkg/modprovider/state.go
+++ b/pkg/modprovider/state.go
@@ -94,12 +94,12 @@ func (moduleStateResourceArgs) ElementType() reflect.Type {
 
 func newModuleStateResource(
 	ctx *pulumi.Context,
-	providerName string,
+	subProviderName string,
 	opts ...pulumi.ResourceOption,
 ) (*moduleStateResource, error) {
 	args := &moduleStateResourceArgs{}
 	var resource moduleStateResource
-	moduleStateResourceType := fmt.Sprintf("%s:index:%s", providerName, moduleStateTypeName)
+	moduleStateResourceType := fmt.Sprintf("%s:index:%s", subProviderName, moduleStateTypeName)
 	err := ctx.RegisterResource(moduleStateResourceType, moduleStateResourceName, args, &resource, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("RegisterResource failed for ModuleStateResource: %w", err)

--- a/pkg/modprovider/state_test.go
+++ b/pkg/modprovider/state_test.go
@@ -30,6 +30,10 @@ func TestCreateModuleSavesModuleState(t *testing.T) {
 		t:     t,
 		proj:  "myproj",
 		stack: "mystack",
+		params: &ParameterizeArgs{
+			TFModuleSource:  "terraform-aws-modules/vpc/aws",
+			TFModuleVersion: "5.16.0",
+		},
 	}
 	checkModuleStateIsSaved(t, s)
 }
@@ -41,6 +45,10 @@ func TestUpdateModuleSavesModuleState(t *testing.T) {
 		t:     t,
 		proj:  "myproj",
 		stack: "mystack",
+		params: &ParameterizeArgs{
+			TFModuleSource:  "terraform-aws-modules/vpc/aws",
+			TFModuleVersion: "5.16.0",
+		},
 		oldModuleState: &pulumirpc.RegisterResourceResponse{
 			Urn:    "",
 			Id:     moduleStateResourceId,
@@ -65,8 +73,8 @@ func checkModuleStateIsSaved(t *testing.T, s *testResourceMonitorServer) {
 		Parameters: &pulumirpc.ParameterizeRequest_Args{
 			Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
 				Args: []string{
-					"terraform-aws-modules/vpc/aws",
-					"5.16.0",
+					string(s.params.TFModuleSource),
+					string(s.params.TFModuleVersion),
 				},
 			},
 		},


### PR DESCRIPTION
In #27 there are changes to infer package and main resource name from the module references. This PR makes sure that we assume less about these names in the tests so that the state tests start working again.