### PR TITLE
devdocs: remove abbreviations to reuse the regular terms

### DIFF
--- a/docs/internals/module-state-resource.md
+++ b/docs/internals/module-state-resource.md
@@ -1,19 +1,20 @@
-# ModuleState Resource
+# moduleStateResource
 
-The ModuleState Custom Resource stores state for its parent Component Resource.
+The moduleStateResource Custom Resource stores state for its parent Component which otherwise would
+be stateless.
 
-Currently Pulumi does not naturally allow Component Resources to have state of their own. ModuleState uses a trick to
-work around this:
+Currently Pulumi does not naturally allow Component Resources to have state of their own. Therefore
+moduleStateResource uses a trick to work around this:
 
 ```
-    ModuleResource (ComponentResource)
+    ModuleComponentResource
        |
-       +-- ModuleStateResource (CustomResource)
+       +-- moduleStateResource (CustomResource)
 
 ```
 
-Pulumi CLI calls `ModuleResource.Construct()` during `pulumi preview` and `pulumi up`. The trick allows construct to read
-and write a state:
+Pulumi CLI calls `ModuleComponentResource.Construct()` during `pulumi preview` and `pulumi up`. The
+trick allows construct to read and write a state:
 
 ``` go
 func (*m) Construct(...) {
@@ -23,41 +24,41 @@ func (*m) Construct(...) {
 }
 ```
 
-Specifically, the state is read when Pulumi CLI calls Create or Diff on ModuleStateResource, and it is written back when
-the ModuleStateResource responds with the updated state.
+Specifically, the state is read when Pulumi CLI calls Create or Diff on the moduleStateResource, and
+it is written back when the moduleStateResource responds with the updated state.
 
-There are Create, Update/Unchagned, and Update/Changed scenarios. The following diagram shows what happens in the
-Update/Changed scenario which is the most complicated one of the three.
+There are Create, Update/Unchagned, and Update/Changed scenarios. The following diagram shows what
+happens in the Update/Changed scenario which is the most complicated one of the three.
 
 ``` mermaid
 
 sequenceDiagram
   participant PulumiCLI
-  participant ModRes
-  participant StateRes
+  participant ModuleComponentResource
+  participant moduleStateResource
 
-  PulumiCLI->>ModRes:  Construct()
-  ModRes->>PulumiCLI:  RegisterResource(StateRes)
+  PulumiCLI->>ModuleComponentResource:  Construct()
+  ModuleComponentResource->>PulumiCLI:  RegisterResource(moduleStateResource)
 
-  PulumiCLI->>StateRes: Check()
-  PulumiCLI->>StateRes: Diff(oldState=o)
+  PulumiCLI->>moduleStateResource: Check()
+  PulumiCLI->>moduleStateResource: Diff(oldState=o)
 
-  StateRes->>ModRes:    oldStatePromise.Fulfill(o) // in-memory
+  moduleStateResource->>ModuleComponentResource:    oldStatePromise.Fulfill(o) // in-memory
 
-  ModRes->>PulumiCLI:   RegisterResource(children...)
-  ModRes->>StateRes:    newStatePromise.Fulfill(n) // in-memory
+  ModuleComponentResource->>PulumiCLI:   RegisterResource(children...)
+  ModuleComponentResource->>moduleStateResource:    newStatePromise.Fulfill(n) // in-memory
 
-  ModRes->>PulumiCLI:   RegisterResourceOutputs()
-  ModRes->>PulumiCLI:   ConstructResult(..)
+  ModuleComponentResource->>PulumiCLI:   RegisterResourceOutputs()
+  ModuleComponentResource->>PulumiCLI:   ConstructResult(..)
 
-  StateRes->>PulumiCLI: DiffResult(o, n)
-  PulumiCLI->>StateRes: Update(...)
+  moduleStateResource->>PulumiCLI: DiffResult(o, n)
+  PulumiCLI->>moduleStateResource: Update(...)
 
 ```
 
-The state read/write is exposed to Pulumi CLI lifecycle methods on the ModuleStateResource (abbreviated StateRes in the
-diagram), but use an in-memory side channel to expose the state to the ModuleResoure (abbreviated ModRes).
+The state read/write is exposed to Pulumi CLI lifecycle methods on the moduleStateResource, but use
+an in-memory side channel to expose the state to the ModuleComponentResource.
 
-For this to work without blocking, ModuleStateResource lifecycle methods have to happen in the same OS process as the
-ModuleResource, and they have to be performed concurrently with `Construct()`, in a dedicated goroutine. Attempting to
-perform them sequentially would deadlock.
+For this to work without blocking, moduleStateResource lifecycle methods have to happen in the same
+OS process as the ModuleComponentResource, and they have to be performed concurrently with
+`Construct()`, in a dedicated goroutine. Attempting to perform them sequentially would deadlock.


### PR DESCRIPTION
It was pointed out that the diagram does not have code-searchable terms and it's harder to correlate to what's happening. This is now fixed by removing abbreviations.