### PR TITLE
Ensure provider is re-built in tests

### DIFF
--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -388,7 +388,7 @@ func ensureCompiledProvider(t *testing.T) string {
 	_, ci := os.LookupEnv("CI")
 	if !ci {
 		// In development ensure the provider binary is up-to-date.
-		cmd := exec.Command("make", "provider")
+		cmd := exec.Command("make", "-B", "provider")
 		cmd.Dir = root
 		out, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Since we've onboarded to ci-management, the Make targets rely on certain changes to the filesystem to actually do anything.

For tests, these changes don't necessarily happen. This pull request ensures `make build` is always run when calling `ensureCompiledProvider` by using the `make -B` (short for `--always-make`) option, which unconditionally makes all targets.


