### PR TITLE
Use correct component name for Delete sandbox file

### DIFF
--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -115,7 +115,7 @@ func NewModuleComponentResource(
 	// Pulumi name as present in the module URN.
 	// The name chosen here will proliferate into ResourceAddress of every child resource as well,
 	// which will get further reused for Pulumi URNs.
-	tfName := GetModuleName(urn)
+	tfName := getModuleName(urn)
 
 	err = tfsandbox.CreateTFFile(tfName, tfModuleSource, tfModuleVersion, tf.WorkingDir(), args)
 	if err != nil {

--- a/pkg/modprovider/state.go
+++ b/pkg/modprovider/state.go
@@ -216,7 +216,7 @@ func (h *moduleStateHandler) Delete(
 	}
 
 	urn := h.mustParseModURN(req.OldInputs)
-	tfName := GetModuleName(urn)
+	tfName := getModuleName(urn)
 
 	err = tfsandbox.CreateTFFile(tfName, moduleSource, moduleVersion, tf.WorkingDir(), resource.PropertyMap{})
 	if err != nil {
@@ -253,7 +253,7 @@ func (*moduleStateHandler) mustParseModURN(pb *structpb.Struct) urn.URN {
 	return urn
 }
 
-// GetModuleName extracts the Pulumi name of the module from the module's URN.
-func GetModuleName(urn urn.URN) string {
+// getModuleName extracts the Terraform module instance name from the module's URN.
+func getModuleName(urn urn.URN) string {
 	return urn.Name()
 }


### PR DESCRIPTION
We were using a dummy module name before.

It turns out that the `oldInputs` have a URN field, which will offer up the name of the Component as specified in the program.

Fixes #118.
