### PR TITLE
Fix hanging updates

### DIFF
--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -111,11 +111,13 @@ func Test_RandMod_TypeScript(t *testing.T) {
 	})
 
 	t.Run("pulumi preview should be empty", func(t *testing.T) {
-		previewResult := pt.Preview(t,
-			optpreview.ErrorProgressStreams(os.Stderr),
-			optpreview.ProgressStreams(os.Stdout),
-		)
+		previewResult := pt.Preview(t)
 		autogold.Expect(map[apitype.OpType]int{apitype.OpType("same"): 5}).Equal(t, previewResult.ChangeSummary)
+	})
+
+	t.Run("pulumi up should be no-op", func(t *testing.T) {
+		upResult := pt.Up(t)
+		autogold.Expect(&map[string]int{"same": 5}).Equal(t, upResult.Summary.ResourceChanges)
 	})
 }
 


### PR DESCRIPTION
Updates should no longer hang - there was a subtle race condition.

In addition to that, updates would panic on child resources missing a Plan in the child_handler. This is fixed by always running planning.

Fixes #125 