### PR TITLE
Add .pulumi/bin to PATH in tests

### DIFF
--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -454,6 +454,8 @@ func pulumiConvert(t *testing.T, localProviderBinPath, sourceDir, targetDir, lan
 
 	path := os.Getenv("PATH")
 	path = fmt.Sprintf("%s:%s", filepath.Dir(localProviderBinPath), path)
+	// add pulumi bin to path. This is required to get tests to work locally
+	path = fmt.Sprintf("%s:%s", filepath.Join(getRoot(t), ".pulumi", "bin"), path)
 
 	cmd.Dir = sourceDir
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PATH=%s", path))


### PR DESCRIPTION
In order to run some of the integration tests locally we need to use the
specific versions of tools in .pulumi/bin. This seems to already work
fine in CI because the Makefile adds to the PATH in the CI environment.