### PR TITLE
Save tofu lockfile to preserve provider choices

### DIFF
--- a/pkg/modprovider/state.go
+++ b/pkg/modprovider/state.go
@@ -17,7 +17,6 @@ package modprovider
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -45,10 +44,12 @@ const (
 type moduleState struct {
 	// Intended to store contents of TF state exactly.
 	rawState []byte
+	// Intended to store contents of TF lock file exactly.
+	rawLockFile []byte
 }
 
 func (ms *moduleState) Equal(other moduleState) bool {
-	return bytes.Equal(ms.rawState, other.rawState)
+	return bytes.Equal(ms.rawState, other.rawState) && bytes.Equal(ms.rawLockFile, other.rawLockFile)
 }
 
 func (ms *moduleState) Unmarshal(s *structpb.Struct) {
@@ -63,6 +64,10 @@ func (ms *moduleState) Unmarshal(s *structpb.Struct) {
 	if !ok {
 		return // empty
 	}
+	if lock, ok := props["lock"]; ok {
+		lockString := lock.StringValue()
+		ms.rawLockFile = []byte(lockString)
+	}
 	stateString := state.StringValue()
 	ms.rawState = []byte(stateString)
 }
@@ -71,6 +76,7 @@ func (ms *moduleState) Marshal() *structpb.Struct {
 	state := resource.PropertyMap{
 		// TODO[pulumi/pulumi-terraform-module#148] store as JSON-y map
 		"state": resource.MakeSecret(resource.NewStringProperty(string(ms.rawState))),
+		"lock":  resource.NewStringProperty(string(ms.rawLockFile)),
 	}
 
 	value, err := plugin.MarshalProperties(state, plugin.MarshalOptions{
@@ -279,14 +285,14 @@ func (h *moduleStateHandler) Delete(
 		return nil, fmt.Errorf("Seed file generation failed: %w", err)
 	}
 
+	err = tf.PushStateAndLockFile(ctx, oldState.rawState, oldState.rawLockFile)
+	if err != nil {
+		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
+	}
+
 	err = tf.Init(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Init failed: %w", err)
-	}
-
-	err = tf.PushState(ctx, oldState.rawState)
-	if err != nil {
-		return nil, fmt.Errorf("PushState failed: %w", err)
 	}
 
 	err = tf.Destroy(ctx)
@@ -340,9 +346,9 @@ func (h *moduleStateHandler) Read(
 	oldState := moduleState{}
 	oldState.Unmarshal(req.GetProperties())
 
-	err = tf.PushState(ctx, oldState.rawState)
+	err = tf.PushStateAndLockFile(ctx, oldState.rawState, oldState.rawLockFile)
 	if err != nil {
-		return nil, fmt.Errorf("PushState failed: %w", err)
+		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
 
 	plan, err := tf.PlanRefreshOnly(ctx)
@@ -362,16 +368,14 @@ func (h *moduleStateHandler) Read(
 	// Child resources need to access the state in their Read() implementation.
 	h.planStore.SetState(modUrn, state)
 
-	rawState, ok, err := tf.PullState(ctx)
+	rawState, rawLockFile, err := tf.PullStateAndLockFile(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("PullState failed: %w", err)
-	}
-	if !ok {
-		return nil, errors.New("PullState did not find state")
+		return nil, fmt.Errorf("PullStateAndLockFile failed: %w", err)
 	}
 
 	refreshedModuleState := moduleState{
-		rawState: rawState,
+		rawState:    rawState,
+		rawLockFile: rawLockFile,
 	}
 
 	// The engine will call Diff() after Read(), and it would expect this to be populated.

--- a/pkg/tfsandbox/state.go
+++ b/pkg/tfsandbox/state.go
@@ -25,18 +25,22 @@ import (
 const defaultStateFile = "terraform.tfstate"
 const defaultLockFile = ".terraform.lock.hcl"
 
-func (t *Tofu) PullStateAndLockFile(_ context.Context) (json.RawMessage, []byte, error) {
-	state, err := t.pullState(context.Background())
+// PullStateAndLockFile reads the state and lock file from the Tofu working directory.
+// If the lock file is not present, it returns nil for the lock file and no error.
+// It's possible for modules to not have any providers which would mean no lock file
+func (t *Tofu) PullStateAndLockFile(_ context.Context) (state json.RawMessage, lockFile []byte, err error) {
+	state, err = t.pullState(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
-	lock, err := t.pullLockFile(context.Background())
+	lockFile, err = t.pullLockFile(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
-	return state, lock, nil
+	return state, lockFile, nil
 }
 
+// PushStateAndLockFile writes the state and lock file to the Tofu working directory.
 func (t *Tofu) PushStateAndLockFile(_ context.Context, state json.RawMessage, lock []byte) error {
 	if err := t.pushState(context.Background(), state); err != nil {
 		return err

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -71,9 +71,8 @@ func TestState(t *testing.T) {
 		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
 	}, moduleOutputs)
 
-	rawState, ok, err := tofu.PullState(ctx)
+	rawState, rawLockFile, err := tofu.PullStateAndLockFile(ctx)
 	require.NoError(t, err, "error pulling tofu state")
-	require.True(t, ok, "no tofu state found")
 
 	type stateModel struct {
 		Resources []any `json:"resources"`
@@ -95,7 +94,7 @@ func TestState(t *testing.T) {
 	// Now modify the state and run a plan.
 
 	newState := bytes.ReplaceAll(rawState, []byte(`"test"`), []byte(`"test2"`))
-	err = tofu.PushState(ctx, newState)
+	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
 	require.NoError(t, err, "error pushing tofu state")
 
 	plan, err := tofu.Plan(ctx)


### PR DESCRIPTION
This PR adds the Tofu
[lockfile](https://opentofu.org/docs/language/files/dependency-lock/) to
the ModuleState resource. Now whenever we push/pull state we also
push/pull the lockfile. Using the lockfile will ensure that every time
we run tofu we will always select the same version of the providers.

One thing to note is that when the lockfile is created during `tofu init` it has a `h1:` checksum and a bunch of `zh:` checksums. The `zh:` checksums are the checksums for each platform supported by that provider and the `h1:` checksum is the checksum created for the local platform. So this is a scenario that could happen

1. User runs terraform init on `macos`
2. `h1:` entry created for `macos`
3. Terraform run in CI on linux machine
4. Terraform picks the version of the provider based on the lockfile, but downloads the provider for linux and creates a new `h1:` entry for the linux os.

In that case the `ModuleState` resource would update the `lock` property. The only alternative would be to run the `tofu providers lock` command with each platform (e.g. `tofu providers lock -platform darwin_arm64 -platform darwin_amd64 ...`). The problem with that is that there is no caching involved in that command each provider for each platform would need to be run each time `tofu providers lock` is run. This would be a huge performance hit. There is a good [explanation for how this command works](https://github.com/opentofu/opentofu/issues/1442#issuecomment-2389746080) 

closes #115 