### PR TITLE
Use a shared cache directory for provider plugins

### DIFF
--- a/pkg/tfsandbox/tofu.go
+++ b/pkg/tfsandbox/tofu.go
@@ -74,7 +74,7 @@ func NewTofu(ctx context.Context, workdir Workdir) (*Tofu, error) {
 	// Use a common cache directory for provider plugins
 	env := envMap(os.Environ())
 	env["TF_PLUGIN_CACHE_DIR"] = cacheDir
-	if err := tf.SetEnv(env); err != nil {
+	if err := tf.SetEnv(tfexec.CleanEnv(env)); err != nil {
 		return nil, fmt.Errorf("error setting env var TF_PLUGIN_CACHE_DIR: %w", err)
 	}
 	return &Tofu{


### PR DESCRIPTION
This configures a shared
[TF_PLUGIN_CACHE_DIR](https://opentofu.org/docs/cli/config/environment-variables/#tf_plugin_cache_dir)
for provider plugins. I've reused the same location that the dynamic
providers use to install terraform providers.

Tofu will now use that as the download location and will link it to the
local `.terraform` directory.

**Alternative Considered**

One alternative I considered was to instead use a shared [TF_DATA_DIR](https://opentofu.org/docs/cli/config/environment-variables/#tf_data_dir)
which would move the local `.terraform` directory to a shared location.
This would also mean we would cache the downloaded modules in this
shared location as well. I chose to go with the `CACHE_DIR` because it
was the more established pattern, but we could explore that more if we
want.

re #159