### PR TITLE
[ux] Stream logs from tofu

### DIFF
--- a/pkg/modprovider/logger.go
+++ b/pkg/modprovider/logger.go
@@ -1,0 +1,93 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modprovider
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
+)
+
+// componentLogger is an implementation of tfsandbox.Logger that sends log messages to a Pulumi Log and associates them
+// with a particular resource. This is used to write status messages from plan/apply to the Pulumi UI.
+type componentLogger struct {
+	log      pulumi.Log
+	resource pulumi.Resource
+}
+
+func newComponentLogger(log pulumi.Log, resource pulumi.Resource) tfsandbox.Logger {
+	return &componentLogger{log: log, resource: resource}
+}
+
+func (l *componentLogger) Log(level tfsandbox.LogLevel, message string) {
+	if l.log == nil {
+		return
+	}
+
+	err := func() error {
+		args := &pulumi.LogArgs{
+			Resource:  l.resource,
+			Ephemeral: true,
+		}
+		switch level {
+		case tfsandbox.Debug:
+			return l.log.Debug(message, args)
+		case tfsandbox.Info:
+			return l.log.Info(message, args)
+		case tfsandbox.Warn:
+			return l.log.Warn(message, args)
+		case tfsandbox.Error:
+			return l.log.Error(message, args)
+		}
+		return nil
+	}()
+	contract.IgnoreError(err)
+}
+
+// resourceLogger is an implementation of tfsandbox.Logger that sends log messages to a Pulumi host and associates them
+// with a particular URN. This is used to write status messages from destroy et. al. to the Pulumi UI.
+type resourceLogger struct {
+	hc  *provider.HostClient
+	urn resource.URN
+}
+
+func newResourceLogger(hc *provider.HostClient, urn resource.URN) tfsandbox.Logger {
+	return &resourceLogger{hc: hc, urn: urn}
+}
+
+func (l *resourceLogger) Log(level tfsandbox.LogLevel, message string) {
+	if l.hc == nil {
+		return
+	}
+
+	severity := diag.Debug
+	switch level {
+	case tfsandbox.Info:
+		severity = diag.Info
+	case tfsandbox.Warn:
+		severity = diag.Warning
+	case tfsandbox.Error:
+		severity = diag.Error
+	}
+
+	err := l.hc.LogStatus(context.TODO(), severity, l.urn, message)
+	contract.IgnoreError(err)
+}

--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -156,7 +156,9 @@ func NewModuleComponentResource(
 		return nil, nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
 
-	err = tf.Init(ctx.Context())
+	logger := newComponentLogger(ctx.Log, &component)
+
+	err = tf.Init(ctx.Context(), logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Init failed: %w", err)
 	}
@@ -165,7 +167,7 @@ func NewModuleComponentResource(
 
 	// Plans are always needed, so this code will run in DryRun and otherwise. In the future we
 	// may be able to reuse the plan from DryRun for the subsequent application.
-	plan, err := tf.Plan(ctx.Context())
+	plan, err := tf.Plan(ctx.Context(), logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Plan failed: %w", err)
 	}
@@ -212,7 +214,7 @@ func NewModuleComponentResource(
 		moduleOutputs = plan.Outputs()
 	} else {
 		// DryRun() = false corresponds to running pulumi up
-		tfState, err := tf.Apply(ctx.Context())
+		tfState, err := tf.Apply(ctx.Context(), logger)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Apply failed: %w", err)
 		}

--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -79,7 +79,8 @@ func (s *server) Parameterize(
 	s.componentTypeName = defaultComponentTypeName
 	s.packageName = pargs.PackageName
 	s.packageVersion = inferPackageVersion(pargs.TFModuleVersion)
-	inferredModuleSchema, err := InferModuleSchema(ctx, s.packageName, pargs.TFModuleSource, pargs.TFModuleVersion)
+	logger := newResourceLogger(s.hostClient, "")
+	inferredModuleSchema, err := inferModuleSchema(ctx, s.packageName, pargs.TFModuleSource, pargs.TFModuleVersion, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error while inferring module schema for '%s' version %s: %w",
 			pargs.TFModuleSource,

--- a/pkg/modprovider/state.go
+++ b/pkg/modprovider/state.go
@@ -292,12 +292,14 @@ func (h *moduleStateHandler) Delete(
 		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
 
-	err = tf.Init(ctx)
+	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
+
+	err = tf.Init(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Init failed: %w", err)
 	}
 
-	err = tf.Destroy(ctx)
+	err = tf.Destroy(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Delete failed: %w", err)
 	}
@@ -354,7 +356,9 @@ func (h *moduleStateHandler) Read(
 		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
 
-	plan, err := tf.PlanRefreshOnly(ctx)
+	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
+
+	plan, err := tf.PlanRefreshOnly(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Planning module refresh failed: %w", err)
 	}
@@ -363,7 +367,7 @@ func (h *moduleStateHandler) Read(
 	h.planStore.SetPlan(modUrn, plan)
 
 	// Now actually apply the refresh.
-	state, err := tf.Refresh(ctx)
+	state, err := tf.Refresh(ctx, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Module refresh failed: %w", err)
 	}

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -24,11 +24,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
 func TestExtractModuleContentWorks(t *testing.T) {
 	ctx := context.Background()
-	awsVpc, err := extractModuleContent(ctx, "terraform-aws-modules/vpc/aws", "5.18.1")
+	awsVpc, err := extractModuleContent(ctx, "terraform-aws-modules/vpc/aws", "5.18.1", tfsandbox.DiscardLogger)
 	assert.NoError(t, err, "failed to infer module schema for aws vpc module")
 	assert.NotNil(t, awsVpc, "inferred module schema for aws vpc module is nil")
 }
@@ -157,7 +159,7 @@ func TestResolveModuleSources(t *testing.T) {
 		src := filepath.Join("..", "..", "tests", "testdata", "modules", "randmod")
 		p, err := filepath.Abs(src)
 		require.NoError(t, err)
-		d, err := resolveModuleSources(ctx, TFModuleSource(p), "")
+		d, err := resolveModuleSources(ctx, TFModuleSource(p), "", tfsandbox.DiscardLogger)
 		require.NoError(t, err)
 
 		bytes, err := os.ReadFile(filepath.Join(d, "variables.tf"))
@@ -173,7 +175,7 @@ func TestResolveModuleSources(t *testing.T) {
 		ctx := context.Background()
 		s := TFModuleSource("terraform-aws-modules/s3-bucket/aws")
 		v := TFModuleVersion("4.5.0")
-		d, err := resolveModuleSources(ctx, s, v)
+		d, err := resolveModuleSources(ctx, s, v, tfsandbox.DiscardLogger)
 		require.NoError(t, err)
 
 		bytes, err := os.ReadFile(filepath.Join(d, "variables.tf"))

--- a/pkg/tfsandbox/apply.go
+++ b/pkg/tfsandbox/apply.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Apply runs the terraform apply command and returns the final state
-func (t *Tofu) Apply(ctx context.Context) (*State, error) {
-	state, err := t.apply(ctx)
+func (t *Tofu) Apply(ctx context.Context, logger Logger) (*State, error) {
+	state, err := t.apply(ctx, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +22,11 @@ func (t *Tofu) Apply(ctx context.Context) (*State, error) {
 }
 
 // Apply runs the terraform apply command and returns the final state
-func (t *Tofu) apply(ctx context.Context) (*tfjson.State, error) {
-	if err := t.tf.Apply(ctx); err != nil {
+func (t *Tofu) apply(ctx context.Context, logger Logger) (*tfjson.State, error) {
+	logWriter := newJSONLogPipe(ctx, logger)
+	defer logWriter.Close()
+
+	if err := t.tf.ApplyJSON(ctx, logWriter); err != nil {
 		return nil, fmt.Errorf("error running tofu apply: %w", err)
 	}
 

--- a/pkg/tfsandbox/destroy.go
+++ b/pkg/tfsandbox/destroy.go
@@ -6,8 +6,11 @@ import (
 )
 
 // Destroy runs the terraform destroy command
-func (t *Tofu) Destroy(ctx context.Context) error {
-	if err := t.tf.Destroy(ctx); err != nil {
+func (t *Tofu) Destroy(ctx context.Context, log Logger) error {
+	logWriter := newJSONLogPipe(ctx, log)
+	defer logWriter.Close()
+
+	if err := t.tf.DestroyJSON(ctx, logWriter); err != nil {
 		return fmt.Errorf("error running tofu destroy: %w", err)
 	}
 

--- a/pkg/tfsandbox/init.go
+++ b/pkg/tfsandbox/init.go
@@ -8,9 +8,12 @@ import (
 // Run tofu init to initialize a new directory.
 //
 // TODO[pulumi/pulumi-terraform-module#67] speed up this slow operation.
-func (t *Tofu) Init(ctx context.Context) error {
+func (t *Tofu) Init(ctx context.Context, log Logger) error {
+	logWriter := newJSONLogPipe(ctx, log)
+	defer logWriter.Close()
+
 	// Run the terraform init command
-	if err := t.tf.Init(ctx); err != nil {
+	if err := t.tf.InitJSON(ctx, logWriter); err != nil {
 		return fmt.Errorf("error running tofu init: %w", err)
 	}
 

--- a/pkg/tfsandbox/log.go
+++ b/pkg/tfsandbox/log.go
@@ -1,0 +1,85 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfsandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+type LogLevel string
+
+const (
+	Info  LogLevel = "info"
+	Error LogLevel = "error"
+	Warn  LogLevel = "warn"
+	Debug LogLevel = "debug"
+)
+
+type Logger interface {
+	Log(level LogLevel, message string)
+}
+
+type discardLogger struct{}
+
+func (discardLogger) Log(_ LogLevel, _ string) {}
+
+var DiscardLogger Logger = discardLogger{}
+
+func newJSONLogPipe(ctx context.Context, logger Logger) io.WriteCloser {
+	type logMessage struct {
+		Level   LogLevel `json:"@level"`
+		Message string   `json:"@message"`
+	}
+
+	reader, writer := io.Pipe()
+	go func() {
+		defer reader.Close() // Ensure we close the reader on our way out.
+
+		dec := json.NewDecoder(reader)
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+
+			var msg logMessage
+			if err := dec.Decode(&msg); err != nil {
+				// If we encounter a decoding error, log the error and ignore the rest of the output.
+				// We drain the reader rather than returning early here to avoid killing the writer due
+				// to write-after-closed errors.
+				if !errors.Is(err, io.EOF) {
+					logger.Log(Debug, err.Error())
+					_, err = io.Copy(io.Discard, reader)
+					contract.IgnoreError(err)
+				}
+				return
+			}
+
+			switch msg.Level {
+			case Info, Error, Warn:
+				logger.Log(msg.Level, msg.Message)
+			default:
+				logger.Log(Debug, fmt.Sprintf("%v: %v", msg.Level, msg.Message))
+			}
+		}
+	}()
+
+	return writer
+}

--- a/pkg/tfsandbox/refresh.go
+++ b/pkg/tfsandbox/refresh.go
@@ -7,8 +7,8 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func (t *Tofu) Refresh(ctx context.Context) (*State, error) {
-	st, err := t.refresh(ctx)
+func (t *Tofu) Refresh(ctx context.Context, log Logger) (*State, error) {
+	st, err := t.refresh(ctx, log)
 	if err != nil {
 		return nil, err
 	}
@@ -19,8 +19,11 @@ func (t *Tofu) Refresh(ctx context.Context) (*State, error) {
 	return s, nil
 }
 
-func (t *Tofu) refresh(ctx context.Context) (*tfjson.State, error) {
-	if err := t.tf.Refresh(ctx); err != nil {
+func (t *Tofu) refresh(ctx context.Context, log Logger) (*tfjson.State, error) {
+	logWriter := newJSONLogPipe(ctx, log)
+	defer logWriter.Close()
+
+	if err := t.tf.RefreshJSON(ctx, logWriter); err != nil {
 		return nil, fmt.Errorf("error running tofu refresh: %w", err)
 	}
 

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -47,10 +47,10 @@ func TestState(t *testing.T) {
 		}), outputs, providersConfig)
 	require.NoError(t, err, "error creating tf file")
 
-	err = tofu.Init(ctx)
+	err = tofu.Init(ctx, DiscardLogger)
 	require.NoError(t, err, "error running tofu init")
 
-	initialPlan, err := tofu.Plan(ctx)
+	initialPlan, err := tofu.Plan(ctx, DiscardLogger)
 	require.NoError(t, err, "error running tofu plan (before apply)")
 	require.NotNil(t, initialPlan, "expected a non-nil plan")
 
@@ -61,7 +61,7 @@ func TestState(t *testing.T) {
 		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
 	}, plannedOutputs)
 
-	state, err := tofu.Apply(ctx)
+	state, err := tofu.Apply(ctx, DiscardLogger)
 	require.NoError(t, err, "error running tofu apply")
 
 	moduleOutputs := state.Outputs()
@@ -99,7 +99,7 @@ func TestState(t *testing.T) {
 	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
 	require.NoError(t, err, "error pushing tofu state")
 
-	plan, err := tofu.Plan(ctx)
+	plan, err := tofu.Plan(ctx, DiscardLogger)
 	require.NoError(t, err, "error replanning")
 
 	hasUpdates := false
@@ -156,10 +156,10 @@ func TestStateMatchesPlan(t *testing.T) {
 				resource.NewPropertyMapFromMap(inputs), outputs, emptyProviders)
 			require.NoError(t, err, "error creating tf file")
 
-			err = tofu.Init(ctx)
+			err = tofu.Init(ctx, DiscardLogger)
 			require.NoError(t, err, "error running tofu init")
 
-			initialPlan, err := tofu.Plan(ctx)
+			initialPlan, err := tofu.Plan(ctx, DiscardLogger)
 			require.NoError(t, err, "error running tofu plan (before apply)")
 			require.NotNil(t, initialPlan, "expected a non-nil plan")
 
@@ -168,7 +168,7 @@ func TestStateMatchesPlan(t *testing.T) {
 				resource.PropertyKey("number_output"): tc.expected,
 			}, plannedOutputs)
 
-			state, err := tofu.Apply(ctx)
+			state, err := tofu.Apply(ctx, DiscardLogger)
 			require.NoError(t, err, "error running tofu apply")
 			moduleOutputs := state.Outputs()
 			// output value is the same as the input

--- a/pkg/tfsandbox/tofu_test.go
+++ b/pkg/tfsandbox/tofu_test.go
@@ -55,10 +55,10 @@ func TestTofuPlan(t *testing.T) {
 	}), outputs, providersConfig)
 	assert.NoErrorf(t, err, "error creating tf file")
 
-	err = tofu.Init(ctx)
+	err = tofu.Init(ctx, DiscardLogger)
 	assert.NoErrorf(t, err, "error running tofu init")
 
-	plan, err := tofu.plan(ctx)
+	plan, err := tofu.plan(ctx, DiscardLogger)
 	assert.NoErrorf(t, err, "error running tofu plan")
 	childModules := plan.PlannedValues.RootModule.ChildModules
 	assert.Len(t, childModules, 1)
@@ -80,18 +80,18 @@ func TestTofuApply(t *testing.T) {
 	}), emptyOutputs, providersConfig)
 	assert.NoErrorf(t, err, "error creating tf file")
 
-	err = tofu.Init(ctx)
+	err = tofu.Init(ctx, DiscardLogger)
 	assert.NoErrorf(t, err, "error running tofu init")
 
-	state, err := tofu.apply(ctx)
+	state, err := tofu.apply(ctx, DiscardLogger)
 	assert.NoError(t, err)
 	assert.Equal(t, "module.test.terraform_data.example", state.Values.RootModule.ChildModules[0].Resources[0].Address)
 
-	state, err = tofu.refresh(ctx)
+	state, err = tofu.refresh(ctx, DiscardLogger)
 	assert.NoError(t, err, "error running tofu refresh")
 	assert.Equal(t, "module.test.terraform_data.example", state.Values.RootModule.ChildModules[0].Resources[0].Address)
 
-	err = tofu.Destroy(ctx)
+	err = tofu.Destroy(ctx, DiscardLogger)
 	assert.NoErrorf(t, err, "error running tofu destroy")
 }
 

--- a/tests/schema_create_secrets_test.go
+++ b/tests/schema_create_secrets_test.go
@@ -41,7 +41,7 @@ module "local" {
 	assert.NoError(t, err)
 	err = os.MkdirAll(path.Join(tofu.WorkingDir(), "local_module"), 0700)
 	assert.NoError(t, err)
-	err = tofu.Init(ctx)
+	err = tofu.Init(ctx, tfsandbox.DiscardLogger)
 	assert.NoError(t, err)
 
 	t.Run("SDKV2_TypeList", func(t *testing.T) {

--- a/tests/schema_create_test.go
+++ b/tests/schema_create_test.go
@@ -41,7 +41,7 @@ module "local" {
 	err = os.MkdirAll(path.Join(tofu.WorkingDir(), "local_module"), 0700)
 	assert.NoError(t, err)
 
-	err = tofu.Init(ctx)
+	err = tofu.Init(ctx, tfsandbox.DiscardLogger)
 	assert.NoError(t, err)
 
 	t.Run("SDKV2_TypeList", func(t *testing.T) {
@@ -623,7 +623,7 @@ func runPlan(t *testing.T, tofu *tfsandbox.Tofu, tfFile string) *tfsandbox.Plan 
 
 	ctx := context.Background()
 
-	plan, err := tofu.Plan(ctx)
+	plan, err := tofu.Plan(ctx, tfsandbox.DiscardLogger)
 	assert.NoError(t, err)
 	return plan
 }


### PR DESCRIPTION
These changes add support for streaming logs from tofu operations back to the Pulumi engine. The engine will render these logs during previews and updates, where they will be associated with the module's component resource. This makes it easier to understand what is happening during active periods that have no associated resource operations (e.g. while `plan` or `apply` is running).