### PR TITLE
Add Python end to end test

### DIFF
--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -486,13 +486,13 @@ func TestIntegration(t *testing.T) {
 				apitype.OpType("create"): 6,
 			},
 			upExpect: map[string]int{
-				"create": 5,
+				"create": 6,
 			},
 			deleteExpect: map[string]int{
-				"delete": 5,
+				"delete": 6,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 5,
+				apitype.OpType("same"): 6,
 			},
 		},
 		{
@@ -501,16 +501,16 @@ func TestIntegration(t *testing.T) {
 			moduleVersion:   "4.5.0",
 			moduleNamespace: "bucket",
 			previewExpect: map[apitype.OpType]int{
-				apitype.OpType("create"): 6,
+				apitype.OpType("create"): 5,
 			},
 			upExpect: map[string]int{
-				"create": 6,
+				"create": 5,
 			},
 			deleteExpect: map[string]int{
-				"delete": 6,
+				"delete": 5,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 6,
+				apitype.OpType("same"): 5,
 			},
 		},
 		{
@@ -1071,6 +1071,7 @@ func pulumiPackageAdd(
 		t.Errorf("Failed to run pulumi package add\nExit code: %d\nError: %v\n%s\n%s",
 			exitCode, err, stdout, stderr)
 	}
+
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 }

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -466,7 +466,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 func TestE2eTs(t *testing.T) {
 
 	type testCase struct {
-		name                string // Must be same as project folder in testdata/programs
+		name                string // Must be same as project folder in testdata/programs/ts
 		moduleName          string
 		moduleVersion       string
 		moduleNamespace     string
@@ -523,9 +523,7 @@ func TestE2eTs(t *testing.T) {
 		skipLocalRunsWithoutCreds(t)
 		t.Run(tc.name, func(t *testing.T) {
 			testProgram := filepath.Join("testdata", "programs", "ts", tc.name)
-
 			localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
-
 			integrationTest := pulumitest.NewPulumiTest(t, testProgram, localPath)
 
 			// Get a prefix for resource names
@@ -539,7 +537,6 @@ func TestE2eTs(t *testing.T) {
 
 			// Preview
 			previewResult := integrationTest.Preview(t)
-
 			autogold.Expect(tc.previewExpect).Equal(t, previewResult.ChangeSummary)
 
 			// Up
@@ -561,7 +558,7 @@ func TestE2eTs(t *testing.T) {
 func TestE2ePython(t *testing.T) {
 
 	type testCase struct {
-		name                string // Must be same as project folder in testdata/programs
+		name                string // Must be same as project folder in testdata/programs/python
 		moduleName          string
 		moduleVersion       string
 		moduleNamespace     string
@@ -598,14 +595,11 @@ func TestE2ePython(t *testing.T) {
 		skipLocalRunsWithoutCreds(t)
 		t.Run(tc.name, func(t *testing.T) {
 			testProgram := filepath.Join("testdata", "programs", "python", tc.name)
-			testOpts := []opttest.Option{
+			integrationTest := pulumitest.NewPulumiTest(
+				t,
+				testProgram,
 				opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath)),
-				opttest.TestInPlace(),
-				opttest.SkipInstall(),
-				opttest.WorkspaceOptions(),
-			}
-
-			integrationTest := pulumitest.NewPulumiTest(t, testProgram, testOpts...)
+			)
 
 			// Get a prefix for resource names
 			prefix := generateTestResourcePrefix()
@@ -614,30 +608,25 @@ func TestE2ePython(t *testing.T) {
 			integrationTest.SetConfig(t, "prefix", prefix)
 
 			// Generate package
-			pulumiPackageAdd(t, integrationTest, localProviderBinPath, tc.moduleName, tc.moduleVersion, tc.moduleNamespace)
+			pulumiPackageAdd(
+				t,
+				integrationTest,
+				localProviderBinPath,
+				tc.moduleName,
+				tc.moduleVersion,
+				tc.moduleNamespace)
 
-			// Preview
 			previewResult := integrationTest.Preview(t)
-			t.Log(previewResult.StdOut)
-			t.Log(previewResult.StdErr)
-
 			autogold.Expect(tc.previewExpect).Equal(t, previewResult.ChangeSummary)
 
-			// Up
 			upResult := integrationTest.Up(t)
 			autogold.Expect(&tc.upExpect).Equal(t, upResult.Summary.ResourceChanges)
 
-			// Preview expect no changes
 			previewResult = integrationTest.Preview(t)
-			t.Log(previewResult.StdOut)
 			autogold.Expect(tc.diffNoChangesExpect).Equal(t, previewResult.ChangeSummary)
 
-			// Delete
 			destroyResult := integrationTest.Destroy(t)
 			autogold.Expect(&tc.deleteExpect).Equal(t, destroyResult.Summary.ResourceChanges)
-
-			// TODO: Clean-up local test dir?
-
 		})
 	}
 }
@@ -1136,7 +1125,6 @@ func pulumiPackageAdd(
 		t.Errorf("Failed to run pulumi package add\nExit code: %d\nError: %v\n%s\n%s",
 			exitCode, err, stdout, stderr)
 	}
-
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 }

--- a/tests/testdata/programs/python/s3bucketmod/.gitignore
+++ b/tests/testdata/programs/python/s3bucketmod/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+venv/
+sdks/

--- a/tests/testdata/programs/python/s3bucketmod/Pulumi.yaml
+++ b/tests/testdata/programs/python/s3bucketmod/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: s3bucketmod
+description: A minimal Python Pulumi program
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: python
+plugins:
+  providers:
+    - name: terraform-module
+      path: /Users/guin/go/src/github.com/pulumi/pulumi-terraform-module-provider/bin

--- a/tests/testdata/programs/python/s3bucketmod/Pulumi.yaml
+++ b/tests/testdata/programs/python/s3bucketmod/Pulumi.yaml
@@ -5,11 +5,3 @@ runtime:
   options:
     toolchain: pip
     virtualenv: venv
-config:
-  pulumi:tags:
-    value:
-      pulumi:template: python
-plugins:
-  providers:
-    - name: terraform-module
-      path: /Users/guin/go/src/github.com/pulumi/pulumi-terraform-module-provider/bin

--- a/tests/testdata/programs/python/s3bucketmod/__main__.py
+++ b/tests/testdata/programs/python/s3bucketmod/__main__.py
@@ -1,0 +1,14 @@
+"""A Python Pulumi program"""
+
+import pulumi
+import pulumi_bucket as bucket
+
+config = pulumi.Config()
+prefix = config.get('prefix') or pulumi.get_stack()
+
+testbucket = bucket.Module("test-bucket",
+    bucket=f"{prefix}-test-bucket",
+
+)
+
+pulumi.export('bucketARN', testbucket.s3_bucket_arn)

--- a/tests/testdata/programs/python/s3bucketmod/requirements.txt
+++ b/tests/testdata/programs/python/s3bucketmod/requirements.txt
@@ -1,0 +1,3 @@
+sdks/bucket
+
+pulumi>=3.0.0,<4.0.0

--- a/tests/testdata/programs/python/s3bucketmod/requirements.txt
+++ b/tests/testdata/programs/python/s3bucketmod/requirements.txt
@@ -1,3 +1,1 @@
-sdks/bucket
-
 pulumi>=3.0.0,<4.0.0


### PR DESCRIPTION
This is a basic end-to-end test for the purposes of verifying that:

- the Python SDK generates correctly via `pulumi package add`
- The generated SDK works in a small test module, in this case AWS Bucket.

What this test is *not*:
- A comprehensive real-world example on how to use the AWS Bucket module in Python (although we could upgrade it to that in the future).

Part of https://github.com/pulumi/pulumi-terraform-module/issues/94.