### PR TITLE
Fix inconsistent plan error

### DIFF
--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -19,14 +19,15 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/pulumi/pulumi-terraform-module/pkg/property"
-	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/internals"
+
+	"github.com/pulumi/pulumi-terraform-module/pkg/property"
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
 // Parameterized component resource representing the top-level tree of resources for a particular TF module.

--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -19,15 +19,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/pulumi/pulumi-terraform-module/pkg/property"
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/internals"
-
-	"github.com/pulumi/pulumi-terraform-module/pkg/property"
-	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
 // Parameterized component resource representing the top-level tree of resources for a particular TF module.
@@ -183,12 +182,6 @@ func NewModuleComponentResource(
 		var errs []error
 
 		plan.VisitResources(func(rp *tfsandbox.ResourcePlan) {
-			if rp.IsInternalOutputResource() {
-				// skip internal output resources which we created
-				// so that we propagate outputs from module
-				return
-			}
-
 			resourceOptions := []pulumi.ResourceOption{
 				pulumi.Parent(&component),
 			}
@@ -233,12 +226,6 @@ func NewModuleComponentResource(
 
 		var errs []error
 		tfState.VisitResources(func(rp *tfsandbox.ResourceState) {
-			if rp.IsInternalOutputResource() {
-				// skip internal output resources which we created
-				// so that we propagate outputs from module
-				return
-			}
-
 			resourceOptions := []pulumi.ResourceOption{
 				pulumi.Parent(&component),
 			}

--- a/pkg/tfsandbox/testdata/modules/test_module/outputs.tf
+++ b/pkg/tfsandbox/testdata/modules/test_module/outputs.tf
@@ -14,3 +14,12 @@ output "statically_known" {
 output "number_output" {
   value = var.input_number_var
 }
+
+output "nested_sensitive_output" {
+  value = {
+    A = var.input_var
+    B = var.another_input_var
+    # This will be unknown during plan
+    C = terraform_data.example.output
+  }
+}

--- a/pkg/tfsandbox/testdata/modules/test_module/variables.tf
+++ b/pkg/tfsandbox/testdata/modules/test_module/variables.tf
@@ -9,3 +9,8 @@ variable "input_number_var" {
   // we can't pass in a big value
   default = 4222222222222222222
 }
+
+variable "another_input_var" {
+  type    = string
+  default = "default"
+}

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -213,11 +213,12 @@ func CreateTFFile(
 	// NOTE: terraform only allows plain booleans in the output.sensitive field.
 	// i.e. `sensitive: "${issensitive(module.source_module.output_name1)}"` won't work
 	for _, output := range outputs {
-		mOutputs[output.Name] = map[string]interface{}{
-			"value": fmt.Sprintf("${nonsensitive(module.%s.%s)}", name, output.Name),
+		mOutputs[output.Name] = map[string]any{
+			// wrapping in jsondecode/jsonencode to workaround an issue where nonsensitive/issensitive is not recursive
+			"value": fmt.Sprintf("${jsondecode(nonsensitive(jsonencode(module.%s.%s)))}", name, output.Name),
 		}
-		mOutputs[fmt.Sprintf("%s%s", terraformIsSecretOutputPrefix, output.Name)] = map[string]interface{}{
-			"value": fmt.Sprintf("${issensitive(module.%s.%s)}", name, output.Name),
+		mOutputs[fmt.Sprintf("%s%s", terraformIsSecretOutputPrefix, output.Name)] = map[string]any{
+			"value": fmt.Sprintf("${jsondecode(issensitive(jsonencode(module.%s.%s)))}", name, output.Name),
 		}
 	}
 

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -225,6 +225,10 @@ func CreateTFFile(
 		tfFile["output"] = mOutputs
 	}
 
+	if len(resources) > 0 {
+		tfFile["resource"] = resources
+	}
+
 	if len(providers) > 0 {
 		tfFile["provider"] = providers
 	}

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -214,7 +214,7 @@ func CreateTFFile(
 
 		resourceName := fmt.Sprintf("%s%s", terraformDataResourcePrefix, output.Name)
 		resources[terraformDataResourceType][resourceName] = map[string]interface{}{
-			"input": fmt.Sprintf("${module.%s.%s}", name, output.Name),
+			"input": fmt.Sprintf("${try(module.%s.%s, \"\")}", name, output.Name),
 		}
 	}
 


### PR DESCRIPTION
This is a fix for the inconsistent plan error.

### Background

To expose outputs from a module, we need to account for the secretness of the outputs
If you try and output a secret value without setting `sensitive: true` in the output
The deployment will fail. We also need to be able to handle this dynamically since we won't know
the secret status until after the operation, and we need to write the output definition when we create the file (before the operation).

### Previous Solution

In #132 we added support for module outputs by using a `terraform_data` resource as a proxy for the output. This allowed us to account for the dynamic nature of the secret since we could determine the secret status of the value using the same method that we use for all other resource properties.

This ran into an issue #198 where `terraform_data` resources cannot be used if the value may be "inconsistent". A very common case that is used in most modules is to define an output like this:

```hcl
output "default_security_group_id" {
  description = "The ID of the security group created by default on VPC creation"
  value       = try(aws_vpc.this[0].default_security_group_id, null)
}
```

`try` is used because most modules will conditionally create resources and need to handle the case where the resource was not created and the value doesn't exist. This is a common case, but there may be other cases of this "inconsistent" data.

### New Solution

This PR tries a new solution of using output values with a combination of the [nonsensitive](https://developer.hashicorp.com/terraform/language/functions/nonsensitive) and [issensitive](https://developer.hashicorp.com/terraform/language/functions/issensitive) functions. We can use the `issensitive` function to dynamically determine whether the value is sensitive or not. Unfortunately it is not possible to use functions in the `output.sensitive` field (e.g. `sensitive: "${issensitive(module.source_module.output_name1)}"` won't work).

To work around this we use two outputs for each output value:
- The first output is the actual value that we mark as non-sensitive to avoid the error
- The second output is a boolean that indicates whether the value is a secret or not.

```json
"output": {
  "name1": {
      "value": "${nonsensitive(module.source_module.output_name1)}"
  },
  "internal_output_is_secret_name1": {
      "value": "${issensitive(module.source_module.output_name1)}"
  },
  ...
}
```

fixes #198
