### PR TITLE
Remove TF_PLUGIN_CACHE_DIR usage

### DIFF
--- a/pkg/tfsandbox/tofu.go
+++ b/pkg/tfsandbox/tofu.go
@@ -67,23 +67,35 @@ func NewTofu(ctx context.Context, workdir Workdir) (*Tofu, error) {
 		return nil, fmt.Errorf("error creating a tofu executor: %w", err)
 	}
 
-	cacheDir, err := getPluginCacheDir()
-	if err != nil {
-		return nil, fmt.Errorf("error getting plugin cache dir: %w", err)
-	}
-	// Use a common cache directory for provider plugins
-	env := envMap(os.Environ())
-	env["TF_PLUGIN_CACHE_DIR"] = cacheDir
-	if err := tf.SetEnv(tfexec.CleanEnv(env)); err != nil {
-		return nil, fmt.Errorf("error setting env var TF_PLUGIN_CACHE_DIR: %w", err)
-	}
+	// TODO[pulumi/pulumi-terraform-module#199] concurrent access to the plugin cache
+	// if err := setupPluginCache(tf); err != nil {
+	// 	return nil, fmt.Errorf("error setting up plugin cache: %w", err)
+	// }
+
 	return &Tofu{
 		tf: tf,
 	}, nil
 }
 
+//nolint:unused
+func setupPluginCache(tf *tfexec.Terraform) error {
+	cacheDir, err := getPluginCacheDir()
+	if err != nil {
+		return fmt.Errorf("error getting plugin cache dir: %w", err)
+	}
+	// Use a common cache directory for provider plugins
+	env := envMap(os.Environ())
+	env["TF_PLUGIN_CACHE_DIR"] = cacheDir
+	if err := tf.SetEnv(tfexec.CleanEnv(env)); err != nil {
+		return fmt.Errorf("error setting env var TF_PLUGIN_CACHE_DIR: %w", err)
+	}
+	return nil
+}
+
 // getPluginCacheDir returns the directory where the plugin cache should be stored
 // we are reusing the dynamic_tf_plugins directory since it downloads the same provider plugins
+//
+//nolint:unused
 func getPluginCacheDir() (string, error) {
 	pulumiPath, err := workspace.GetPulumiPath("dynamic_tf_plugins")
 	if err != nil {
@@ -97,6 +109,8 @@ func getPluginCacheDir() (string, error) {
 }
 
 // internal helper from tfexec
+//
+//nolint:unused
 func envMap(environ []string) map[string]string {
 	env := map[string]string{}
 	for _, ev := range environ {


### PR DESCRIPTION
I keep running into CI flakes with an error on the `Test_TwoInstances_TypeScript` test.

```console
 error: randmod:index:Module resource 'myrandmod2' has a problem: NewModuleComponentResource failed: Init failed: error running tofu init: exit status 1
```

It seems to happen when there is not a already existing temp folder for both modules (which is always the case for CI). I think it is due to using the shared plugin cache so turning it off for now so I can revisit it after our CI stops failing.

re #199