### PR TITLE
Accept all remote module sources in parameterize call

### DIFF
--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -90,6 +90,36 @@ func TestParseParameterizeRequest(t *testing.T) {
 		assert.Equal(t, packageName("consul"), args.PackageName)
 	})
 
+	t.Run("parses github-based remote module source", func(t *testing.T) {
+		testRequest := &pulumirpc.ParameterizeRequest{
+			Parameters: &pulumirpc.ParameterizeRequest_Args{
+				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
+					Args: []string{"github.com/yemisprojects/s3_website_module_demo", "demoWebsite"},
+				},
+			},
+		}
+		args, err := parseParameterizeRequest(ctx, testRequest)
+		assert.NoError(t, err)
+		assert.Equal(t, TFModuleSource("github.com/yemisprojects/s3_website_module_demo"), args.TFModuleSource)
+		assert.Equal(t, TFModuleVersion(""), args.TFModuleVersion)
+		assert.Equal(t, packageName("demoWebsite"), args.PackageName)
+	})
+
+	t.Run("fails on invalid module source", func(t *testing.T) {
+		testRequest := &pulumirpc.ParameterizeRequest{
+			Parameters: &pulumirpc.ParameterizeRequest_Args{
+				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
+					Args: []string{"absolute-definite-nonsense", "demoWebsite"},
+				},
+			},
+		}
+		args, err := parseParameterizeRequest(ctx, testRequest)
+		assert.Error(t, err)
+		assert.Empty(t, args.TFModuleSource)
+		assert.Empty(t, args.TFModuleVersion)
+		assert.Empty(t, args.PackageName)
+	})
+
 	t.Run("parses value with module source and version spec", func(t *testing.T) {
 		args, err := parseParameterizeRequest(ctx, &pulumirpc.ParameterizeRequest{
 			Parameters: &pulumirpc.ParameterizeRequest_Value{

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -220,6 +220,11 @@ func latestModuleVersion(ctx context.Context, moduleSource string) (*version.Ver
 	switch parsed := parsedSource.(type) {
 	case addrs.ModuleSourceRegistry:
 		source = parsed
+	case addrs.ModuleSourceRemote:
+		// All other valid remote module sources do not support a separate version field
+		// Opentofu will resolve the source by remote address alone.
+		// See https://opentofu.org/docs/language/modules/sources
+		return &version.Version{}, nil
 	default:
 		return nil, fmt.Errorf("module source for %s is not from a remote registry", moduleSource)
 	}

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -266,11 +266,11 @@ func inferModuleSchema(
 	ctx context.Context,
 	packageName packageName,
 	mod TFModuleSource,
-	ver TFModuleVersion,
+	tfModuleVersion TFModuleVersion,
 	logger tfsandbox.Logger,
 ) (*InferredModuleSchema, error) {
 
-	module, err := extractModuleContent(ctx, mod, ver, logger)
+	module, err := extractModuleContent(ctx, mod, tfModuleVersion, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -153,9 +153,9 @@ func TestInferringModuleSchemaWorks(t *testing.T) {
 		"required provider variables are incorrect")
 }
 
-func TestInferringModuleSchemaGitHubSource(t *testing.T) {
+func TestInferModuleSchemaFromGitHubSource(t *testing.T) {
 	ctx := context.Background()
-	packageName := packageName("bucket-demo")
+	packageName := packageName("demoWebsite")
 	version := TFModuleVersion("") // GitHub-sourced modules don't take a version
 	demoSchema, err := InferModuleSchema(ctx, packageName, "github.com/yemisprojects/s3_website_module_demo", version)
 	assert.NoError(t, err, "failed to infer module schema for github module")
@@ -201,7 +201,7 @@ func TestResolveModuleSources(t *testing.T) {
 	})
 
 	// This test will hit the network to download a well-known module from a registry.
-	t.Run("registry remote module source", func(t *testing.T) {
+	t.Run("registry module source", func(t *testing.T) {
 		ctx := context.Background()
 		s := TFModuleSource("terraform-aws-modules/s3-bucket/aws")
 		v := TFModuleVersion("4.5.0")
@@ -215,8 +215,8 @@ func TestResolveModuleSources(t *testing.T) {
 		assert.Contains(t, string(bytes), "putin_khuylo")
 	})
 
-	// This test will attempt to resolve the source for a github-sourced module.
-	t.Run("github module source plain", func(t *testing.T) {
+	// Make a network call to resolve the source for a remote module source on GitHub.
+	t.Run("remote module source github", func(t *testing.T) {
 		ctx := context.Background()
 		moduleSource := TFModuleSource("github.com/yemisprojects/s3_website_module_demo")
 		workingDirectory, err := resolveModuleSources(ctx, moduleSource, "", tfsandbox.DiscardLogger)
@@ -229,7 +229,7 @@ func TestResolveModuleSources(t *testing.T) {
 		assert.Contains(t, string(bytes), "index_document")
 	})
 
-	t.Run("github module source explicit version ref", func(t *testing.T) {
+	t.Run("remote module source with version in source path", func(t *testing.T) {
 		ctx := context.Background()
 		moduleSource := TFModuleSource("github.com/yemisprojects/s3_website_module_demo?ref=v0.0.1")
 		workingDirectory, err := resolveModuleSources(ctx, moduleSource, "", tfsandbox.DiscardLogger)
@@ -242,7 +242,7 @@ func TestResolveModuleSources(t *testing.T) {
 		assert.Contains(t, string(bytes), "index_document")
 	})
 
-	t.Run("github module source with git path prefix", func(t *testing.T) {
+	t.Run("remote module source with git path prefix", func(t *testing.T) {
 		ctx := context.Background()
 		moduleSource := TFModuleSource("git::github.com/yemisprojects/s3_website_module_demo?ref=v0.0.1")
 		workingDirectory, err := resolveModuleSources(ctx, moduleSource, "", tfsandbox.DiscardLogger)
@@ -254,5 +254,4 @@ func TestResolveModuleSources(t *testing.T) {
 		t.Logf("variables.tf: %s", bytes)
 		assert.Contains(t, string(bytes), "index_document")
 	})
-
 }

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -124,10 +124,11 @@ func CreateTFFile(
 	outputs []TFOutputSpec,
 	providerConfig map[string]resource.PropertyMap,
 ) error {
+
 	moduleProps := map[string]interface{}{
 		"source": source,
 	}
-	// local modules don't have a version
+	// local modules and github-based modules don't have a version
 	if version != "" {
 		moduleProps["version"] = version
 	}


### PR DESCRIPTION
This pull request makes a slight adjustment to the source parsing switch in `tfmodules.go` to also accept `addrs.ModuleSourceRemote`. These non-registry, remote modules all only take a `source` argument, but not a `version` argument.

It adds tests to verify that a non-registry-based, remote, module source can be resolved, can have its schema inferred, and is accepted by `tofu.Init`.

This means that 
`pulumi package add terraform-module github.com/username/modulename demo-website` 
is now valid input.

More tests are added to support the newly added parsing behavior. 

The remote example used is a third-party demo repo: https://github.com/yemisprojects/s3_website_module_demo

What this pull request does **not** do:
- Tests for non-GitHub remote module sources (mostly because a good example is hard to find)
- Verify resolution of [package subdirectories](https://opentofu.org/docs/language/modules/sources/#modules-in-package-sub-directories)

Partial fix for #50
