### PR TITLE
Handle partial failures in tofu apply

### DIFF
--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -111,12 +111,13 @@ func newModuleComponentResource(
 
 	contract.AssertNoErrorf(err, "newModuleStateResource failed")
 
+	var applyErr error
 	state := stateStore.AwaitOldState(urn)
 	defer func() {
 		// SetNewState must be called on every possible exit to make sure child resources do
 		// not wait indefinitely for the state. If existing normally, this should have
 		// already happened, but this code makes sure error exists are covered as well.
-		if finalError != nil {
+		if finalError != nil && applyErr == nil {
 			stateStore.SetNewState(urn, state)
 		}
 	}()
@@ -172,6 +173,7 @@ func newModuleComponentResource(
 
 	planStore.SetPlan(urn, plan)
 
+	var tfState *tfsandbox.State
 	if ctx.DryRun() {
 		// DryRun() = true corresponds to running pulumi preview
 
@@ -206,10 +208,7 @@ func newModuleComponentResource(
 		moduleOutputs = plan.Outputs()
 	} else {
 		// DryRun() = false corresponds to running pulumi up
-		tfState, err := tf.Apply(ctx.Context(), logger)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("Apply failed: %w", err)
-		}
+		tfState, applyErr = tf.Apply(ctx.Context(), logger)
 
 		planStore.SetState(urn, tfState)
 
@@ -255,6 +254,10 @@ func newModuleComponentResource(
 	// TODO[pulumi/pulumi-terraform-module#108] avoid deadlock
 	for _, cr := range childResources {
 		cr.Await(ctx.Context())
+	}
+
+	if applyErr != nil {
+		return nil, nil, nil, fmt.Errorf("Apply failed: %w", applyErr)
 	}
 
 	marshalledOutputs := pulumix.MustUnmarshalPropertyMap(ctx, moduleOutputs)

--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -112,11 +112,15 @@ func newModuleComponentResource(
 	contract.AssertNoErrorf(err, "newModuleStateResource failed")
 
 	var applyErr error
+	var tfState *tfsandbox.State
 	state := stateStore.AwaitOldState(urn)
 	defer func() {
 		// SetNewState must be called on every possible exit to make sure child resources do
 		// not wait indefinitely for the state. If existing normally, this should have
 		// already happened, but this code makes sure error exists are covered as well.
+		//
+		// if applyErr != nil then we've already processed the child resources
+		// and can't call `SetNewState`
 		if finalError != nil && applyErr == nil {
 			stateStore.SetNewState(urn, state)
 		}
@@ -173,7 +177,6 @@ func newModuleComponentResource(
 
 	planStore.SetPlan(urn, plan)
 
-	var tfState *tfsandbox.State
 	if ctx.DryRun() {
 		// DryRun() = true corresponds to running pulumi preview
 

--- a/pkg/tfsandbox/apply.go
+++ b/pkg/tfsandbox/apply.go
@@ -9,6 +9,10 @@ import (
 )
 
 // Apply runs the terraform apply command and returns the final state
+//
+// Apply can return both a non-nil State and a non-nil error. If the apply
+// fails, but some resources were created and written to the TF State we will return
+// the state and the apply error.
 func (t *Tofu) Apply(ctx context.Context, logger Logger) (*State, error) {
 	state, applyErr := t.apply(ctx, logger)
 	s, err := newState(state)

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -214,7 +214,6 @@ func TestPartialApply(t *testing.T) {
 		"create": 1,
 		"same":   3,
 	}, changes2)
-	// now the second one is created so we get both outputs
 	assert.Contains(t, upRes2.Outputs, "roleArn")
 }
 

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -335,7 +335,7 @@ func TestTerraformAwsModulesVpcIntoTypeScript(t *testing.T) {
 			"create": expectedResourceCount,
 		})
 
-		moduleState := mustFindDeploymentResourceByType(t, pt, "vpc:tf:ModuleState")
+		moduleState := mustFindDeploymentResourceByType(t, pt, "vpc:index:ModuleState")
 
 		tfStateRaw, gotTfState := moduleState.Outputs["state"]
 		require.True(t, gotTfState)

--- a/tests/testdata/programs/ts/partial-apply/Pulumi.yaml
+++ b/tests/testdata/programs/ts/partial-apply/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: partial-apply
+runtime: nodejs
+description: A minimal TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: typescript

--- a/tests/testdata/programs/ts/partial-apply/index.ts
+++ b/tests/testdata/programs/ts/partial-apply/index.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as localmod from '@pulumi/localmod';
+
+const config = new pulumi.Config();
+const prefix = config.get('prefix') ?? pulumi.getStack();
+const step = config.getNumber('step') ?? 1;
+
+const mod = new localmod.Module('test-localmod', {
+    name_prefix: prefix,
+    should_fail: step === 1 ? true : false,
+});
+
+export const roleArn =  mod.role_arn;
+

--- a/tests/testdata/programs/ts/partial-apply/local_module/main.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/main.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_role" "this" {
+  name_prefix = var.name_prefix
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  fail_arn    = "arn:aws:iam::aws:policy/ReadOnlyAccessFAIL"
+  success_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.should_fail ? local.fail_arn : local.success_arn
+}

--- a/tests/testdata/programs/ts/partial-apply/local_module/main.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/main.tf
@@ -15,8 +15,6 @@ resource "aws_iam_role" "this" {
   })
 }
 
-data "aws_caller_identity" "current" {}
-
 locals {
   fail_arn    = "arn:aws:iam::aws:policy/ReadOnlyAccessFAIL"
   success_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"

--- a/tests/testdata/programs/ts/partial-apply/local_module/outputs.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/outputs.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}

--- a/tests/testdata/programs/ts/partial-apply/local_module/variables.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/variables.tf
@@ -1,0 +1,9 @@
+variable "name_prefix" {
+  type        = string
+  description = "Prefix to use for the name of the IAM role"
+}
+
+variable "should_fail" {
+  type        = bool
+  description = "Whether the module should fail"
+}

--- a/tests/testdata/programs/ts/partial-apply/package.json
+++ b/tests/testdata/programs/ts/partial-apply/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "partial-apply",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "^3.0.0",
+		"typescript": "^5.0.0"
+	}
+}


### PR DESCRIPTION
This PR handles the case where `tofu apply` fails, but some resources
have been provisioned. As long as we can read the TF state file we will
continue to process the child resources and only after they have been
processed will we fail the component.

This is what a partial deployment will look like now (based on the
example test added).

```console
Previewing update (chall)

View in Browser (Ctrl+O): https://app.pulumi.com/chall-pulumi-corp/partial-apply/chall/previews/b0d1e4be-9ef0-4f84-9211-a241baed39fa

     Type                                              Name                                                      Plan       Info
 +   pulumi:pulumi:Stack                               partial-apply-chall                                       create     2 warnings
 +   └─ localmod:index:Module                          test-localmod                                             create
 +      ├─ localmod:index:ModuleState                  test-localmod-state                                       create
 +      ├─ localmod:tf:aws_iam_role_policy_attachment  module.test-localmod.aws_iam_role_policy_attachment.this  create
 +      └─ localmod:tf:aws_iam_role                    module.test-localmod.aws_iam_role.this                    create

Diagnostics:
  pulumi:pulumi:Stack (partial-apply-chall):
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module

Outputs:
    roleArn: output<string>

Resources:
    + 5 to create

Do you want to perform this update? yes
Updating (chall)

View in Browser (Ctrl+O): https://app.pulumi.com/chall-pulumi-corp/partial-apply/chall/updates/8

     Type                              Name                                    Status                  Info
 +   pulumi:pulumi:Stack               partial-apply-chall                     **creating failed**     1 error; 2 warnings
 +   └─ localmod:index:Module          test-localmod                           **creating failed**     1 error
 +      ├─ localmod:index:ModuleState  test-localmod-state                     created (6s)
 +      └─ localmod:tf:aws_iam_role    module.test-localmod.aws_iam_role.this  created (0.52s)

Diagnostics:
  localmod:index:Module (test-localmod):
    error:
    Error: attaching IAM Policy (arn:aws:iam::aws:policy/ReadOnlyAccessFAIL) to IAM Role (chall20250325181048301400000001): operation error IAM: AttachRolePolicy, https response error StatusCode: 404, RequestID: eb96a2d4-87bc-48d0-9708-b62cf8a69f7f, NoSuchEntity: Policy arn:aws:iam::aws:policy/ReadOnlyAccessFAIL does not exist or is not attachable.

      with module.test-localmod.aws_iam_role_policy_attachment.this,
      on .terraform/modules/test-localmod/main.tf line 31, in resource "aws_iam_role_policy_attachment" "this":
      31: resource "aws_iam_role_policy_attachment" "this" {

  pulumi:pulumi:Stack (partial-apply-chall):
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module
    error: localmod:index:Module resource 'test-localmod' has a problem: NewModuleComponentResource failed: Apply failed: exit status 1

Resources:
    + 4 created

Duration: 11s

❯ pulumi up
aws-vault exec dev-admin -- pulumi up
Previewing update (chall)

View in Browser (Ctrl+O): https://app.pulumi.com/chall-pulumi-corp/partial-apply/chall/previews/2ba3b950-11c3-408e-864f-8dc31103ba2b

     Type                                              Name                                                      Plan       Info
     pulumi:pulumi:Stack                               partial-apply-chall                                                  2 warnings
     └─ localmod:index:Module                          test-localmod
 +      └─ localmod:tf:aws_iam_role_policy_attachment  module.test-localmod.aws_iam_role_policy_attachment.this  create

Diagnostics:
  pulumi:pulumi:Stack (partial-apply-chall):
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module
    warning: using pulumi-resource-terraform-module from $PATH at /Users/chall/work/pulumi-terraform-module/partial-deploy/bin/pulumi-resource-terraform-module

Outputs:
  + roleArn: "arn:aws:iam::616138583583:role/chall20250325181048301400000001"

Resources:
    + 1 to create
    4 unchanged
```

## Notes

- We show the error on the module component resource and the user never
  sees the resource that fails. If we were to ever solve #247 we might
  be able to also attach the error to the correct child resource

## Questions

- [ ] Are there cases where Terraform will fail to create a resource and
  save a partial state? I'm not sure how the next up is handled, would
  it be an update or a create?

fixes #183