### PR TITLE
Share registerChildResources logic

### DIFF
--- a/pkg/modprovider/child.go
+++ b/pkg/modprovider/child.go
@@ -55,18 +55,18 @@ func (cr *childResource) Await(ctx context.Context) {
 	contract.AssertNoErrorf(err, "URN should not fail")
 }
 
-func newChildResource(
+func registerChildResource(
 	ctx *pulumi.Context,
 	modUrn resource.URN,
 	pkgName packageName,
-	sop ResourceStateOrPlan,
+	sop ResourcePlan,
 	packageRef string,
 	opts ...pulumi.ResourceOption,
 ) (*childResource, error) {
 	contract.Assertf(ctx != nil, "ctx must not be nil")
 	contract.Assertf(sop != nil, "sop must not be nil")
 	var resource childResource
-	inputs := childResourceInputs(modUrn, sop.Address(), sop.Values())
+	inputs := childResourceInputs(modUrn, sop.Address(), sop.PlannedValues())
 	t := childResourceTypeToken(pkgName, sop.Type())
 	name := childResourceName(sop)
 	inputsMap := pulumix.MustUnmarshalPropertyMap(ctx, inputs)

--- a/pkg/modprovider/child.go
+++ b/pkg/modprovider/child.go
@@ -263,7 +263,11 @@ func (h *childHandler) Create(
 		}, nil
 	}
 
-	rstate := h.planStore.MustFindResourceState(modUrn, addr)
+	rstate, err := h.planStore.FindResourceState(modUrn, addr)
+	if err != nil {
+		// If a resource was planned but cannot be found in the state, it may have failed to provision.
+		return nil, fmt.Errorf("Create failed")
+	}
 
 	return &pulumirpc.CreateResponse{
 		Id:         childResourceID(rstate),
@@ -284,7 +288,11 @@ func (h *childHandler) Update(
 		}, nil
 	}
 
-	rstate := h.planStore.MustFindResourceState(modUrn, addr)
+	rstate, err := h.planStore.FindResourceState(modUrn, addr)
+	if err != nil {
+		// If a resource was planned but cannot be found in the state, it may have failed to update.
+		return nil, fmt.Errorf("Update failed")
+	}
 
 	return &pulumirpc.UpdateResponse{
 		Properties: h.outputsStruct(childResourceOutputs(rstate)),

--- a/pkg/modprovider/child_test.go
+++ b/pkg/modprovider/child_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
 func TestChildResoruceTypeToken(t *testing.T) {
@@ -76,7 +77,7 @@ func TestChildResourceCreatePreview(t *testing.T) {
 
 	h.planStore.SetPlan(urn.URN(modUrn), &testPlan{
 		byAddress: map[tfsandbox.ResourceAddress]testResourcePlan{
-			tfsandbox.ResourceAddress(addr): testResourcePlan{
+			tfsandbox.ResourceAddress(addr): {
 				resourceAddress: tfsandbox.ResourceAddress(addr),
 				changeKind:      tfsandbox.Create,
 				name:            "this",

--- a/pkg/modprovider/child_test.go
+++ b/pkg/modprovider/child_test.go
@@ -129,7 +129,7 @@ func TestChildResourceCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	createdProperties := resp.Properties.AsMap()
-	assert.Equal(t, 0, len(createdProperties))
+	assert.Equal(t, 1, len(createdProperties))
 	assert.NotEmpty(t, resp.Id)
 }
 

--- a/pkg/modprovider/planstore.go
+++ b/pkg/modprovider/planstore.go
@@ -192,12 +192,3 @@ func (s *planStore) MustFindResourcePlan(
 	contract.AssertNoErrorf(err, "Unexpected failure in FindResourcePlan: %v", err)
 	return result
 }
-
-func (s *planStore) MustFindResourceState(
-	modUrn urn.URN,
-	addr ResourceAddress,
-) ResourceState {
-	result, err := s.FindResourceState(modUrn, addr)
-	contract.AssertNoErrorf(err, "Unexpected failure in FindResourceState: %v", err)
-	return result
-}

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -103,19 +103,23 @@ func Test_RandMod_TypeScript(t *testing.T) {
 		//nolint:lll
 		autogold.Expect(urn.URN("urn:pulumi:test::ts-randmod-program::randmod:index:Module$randmod:tf:random_integer::module.myrandmod.random_integer.priority")).Equal(t, randInt.URN)
 		autogold.Expect(resource.ID("module.myrandmod.random_integer.priority")).Equal(t, randInt.ID)
-		autogold.Expect(map[string]any{
+		autogold.Expect(map[string]interface{}{
 			"__address": "module.myrandmod.random_integer.priority",
 			"__module":  "urn:pulumi:test::ts-randmod-program::randmod:index:Module::myrandmod",
-			"id":        "2",
 			"max":       10,
 			"min":       1,
-			"result":    2,
-			"seed": map[string]any{
+			"seed": map[string]interface{}{
 				"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
 				"plaintext":                        `"9"`,
 			},
 		}).Equal(t, randInt.Inputs)
-		autogold.Expect(map[string]any{}).Equal(t, randInt.Outputs)
+		autogold.Expect(map[string]interface{}{
+			"id": "2", "keepers": nil, "max": 10, "min": 1, "result": 2,
+			"seed": map[string]interface{}{
+				"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+				"plaintext":                        `"9"`,
+			},
+		}).Equal(t, randInt.Outputs)
 	})
 
 	t.Run("pulumi preview should be empty", func(t *testing.T) {


### PR DESCRIPTION
Exploring a change inspired by conversations with @EronWright 

What if we make a distinction between TF planned values (possibly containing unknowns) and TF realized values from the state. Make a change to ensure:

```
planned values = pulumi inputs
realized values = pulumi outputs
```

So then: 

1. pass planned values to RegisterResource (these are inputs)
2. return state values out of Create, Update (these are outputs)
3. diff will only show input changes, which seems like an improvement in UX, reduce noise

In well-behaved TF outputs should be specializing inputs exactly up to unknown substitution, though in some legacy providers this is violated slightly in a benign manner.

There are some concerns on whether it is legitimate to pass unknowns to RegisterResource. I have been told Pulumi may be tolerating these in https://www.pulumi.com/blog/continue-on-error/ ; alternatively we can drop them.

Possibly this also makes resources "show up" sooner to the user? 

Possibly fixes https://github.com/pulumi/pulumi-terraform-module/issues/121
Possibly fixes https://github.com/pulumi/pulumi-terraform-module/issues/247