### PR TITLE
Allow for module configuration and schema override

### DIFF
--- a/pkg/modprovider/child.go
+++ b/pkg/modprovider/child.go
@@ -361,9 +361,6 @@ func (h *childHandler) Read(
 		// Refresh has removed the resource to reflect that it can no longer be found.
 		return &pulumirpc.ReadResponse{Id: ""}, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("Error during child resource Read: %w", err)
-	}
 	inputs := childResourceInputs(modUrn, rstate.Address(), rstate.AttributeValues())
 	return &pulumirpc.ReadResponse{
 		Id:         childResourceID(rstate),

--- a/pkg/modprovider/module_schema_overrides/README.md
+++ b/pkg/modprovider/module_schema_overrides/README.md
@@ -1,0 +1,67 @@
+### Module Schema Overrides
+
+This directory contains JSON files which serves as _known_ module schema overrides for popular Terraform modules. The purpose of these overrides is the enrich the inferred module schema with additional information, especially around correct output types since we are not inferring those correctly yet. 
+
+The structure of these JSON is expected to be marshalled into this Go struct:
+```go
+type ModuleSchemaOverride struct {
+	Source         string                `json:"source"`
+	PartialSchema  *InferredModuleSchema `json:"partialSchema"`
+	MinimumVersion *string               `json:"minimumVersion,omitempty"`
+	MaximumVersion string                `json:"maximumVersion"`
+}
+```
+and `InferredModuleSchema` is defined as:
+```go
+type InferredModuleSchema struct {
+	Inputs          map[string]*schema.PropertySpec    `json:"inputs"`
+	Outputs         map[string]*schema.PropertySpec    `json:"outputs"`
+	SupportingTypes map[string]*schema.ComplexTypeSpec `json:"supportingTypes"`
+	RequiredInputs  []string                           `json:"requiredInputs"`
+	NonNilOutputs   []string                           `json:"nonNilOutputs"`
+}
+```
+
+### Example schema override
+
+Here is how a full example of a schema override looks like. 
+
+Notice how we use a placeholder `[packageName]` for references and type tokens because the package name is only known after the user has provided it themselves. 
+```json
+{
+    "source": "example-module-source-for-testing",
+    "maximumVersion": "6.0.0",
+    "minimumVersion": "0.1.0",
+    "partialSchema": {
+        "inputs": {
+            "example_input": {
+                "type": "string",
+                "description": "An example input for the module."
+            },
+            "example_ref": {
+                "$ref": "#/types/[packageName]:index:MyType"
+            }
+        },
+        "outputs": {
+            "example_output": {
+                "type": "boolean",
+                "description": "An example output for the module."
+            }
+        },
+        "requiredInputs": ["example_input"],
+        "nonNilOutputs": ["example_output"],
+        "supportingTypes": {
+            "[packageName]:index:MyType": {
+                "type": "object",
+                "description": "An example supporting type for the module.",
+                "properties": {
+                    "example_property": {
+                        "type": "string",
+                        "description": "An example property for the supporting type."
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/pkg/modprovider/module_schema_overrides/README.md
+++ b/pkg/modprovider/module_schema_overrides/README.md
@@ -19,6 +19,7 @@ type InferredModuleSchema struct {
 	SupportingTypes map[string]*schema.ComplexTypeSpec `json:"supportingTypes"`
 	RequiredInputs  []string                           `json:"requiredInputs"`
 	NonNilOutputs   []string                           `json:"nonNilOutputs"`
+	ProvidersConfig schema.ConfigSpec                  `json:"providersConfig"`
 }
 ```
 

--- a/pkg/modprovider/module_schema_overrides/example-schema.json
+++ b/pkg/modprovider/module_schema_overrides/example-schema.json
@@ -1,0 +1,36 @@
+{
+    "source": "example-module-source-for-testing",
+    "maximumVersion": "6.0.0",
+    "minimumVersion": "0.1.0",
+    "partialSchema": {
+        "inputs": {
+            "example_input": {
+                "type": "string",
+                "description": "An example input for the module."
+            },
+            "example_ref": {
+                "$ref": "#/types/[packageName]:index:MyType"
+            }
+        },
+        "outputs": {
+            "example_output": {
+                "type": "boolean",
+                "description": "An example output for the module."
+            }
+        },
+        "requiredInputs": ["example_input"],
+        "nonNilOutputs": ["example_output"],
+        "supportingTypes": {
+            "[packageName]:index:MyType": {
+                "type": "object",
+                "description": "An example supporting type for the module.",
+                "properties": {
+                    "example_property": {
+                        "type": "string",
+                        "description": "An example property for the supporting type."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
@@ -1,0 +1,7 @@
+{
+    "source": "terraform-aws-modules/vpc/aws",
+    "maximumVersion": "6.0.0",
+    "partialSchema": {
+        "nonNilOutputs": ["vpc_id"]
+    }
+}

--- a/pkg/modprovider/params.go
+++ b/pkg/modprovider/params.go
@@ -23,9 +23,18 @@ type (
 	TFModuleVersion = tfsandbox.TFModuleVersion
 )
 
+// the module configuration to be provided via --config <file>
+// where the file is a JSON file. It inlines the inferred module schema
+// to override inputs, outputs etc. but also can have more fields in the future
+// if needed to customize the behavior of the provider.
+type ModuleConfig struct {
+	*InferredModuleSchema `json:",inline"`
+}
+
 // The parameters for the provider identify the Terraform module to specialize to.
 type ParameterizeArgs struct {
 	TFModuleSource  TFModuleSource  `json:"module"`
 	TFModuleVersion TFModuleVersion `json:"version,omitempty"`
 	PackageName     packageName     `json:"packageName"`
+	Config          *ModuleConfig   `json:"config,omitempty"`
 }

--- a/pkg/modprovider/testdata/module_configuration/simple-config.json
+++ b/pkg/modprovider/testdata/module_configuration/simple-config.json
@@ -1,0 +1,3 @@
+{
+    "nonNilOutputs": ["output_name"]
+}

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"embed"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -140,17 +140,126 @@ func TestInferringModuleSchemaWorks(t *testing.T) {
 		assert.Equal(t, expected.Secret, actual.Secret, "output %s secret is incorrect", name)
 		assert.Equal(t, expected.TypeSpec, actual.TypeSpec, "output %s type is incorrect", name)
 	}
+}
 
-	expectedConfigVariables := map[string]schema.PropertySpec{
-		"aws": {
-			TypeSpec:    mapType(anyType),
-			Description: "provider configuration for aws",
-		},
+func TestParsingModuleSchemaOverrides(t *testing.T) {
+	packageName := "vpc"
+	overrides := parseModuleSchemaOverrides(packageName)
+	assert.NotNil(t, overrides, "overrides is nil")
+
+	var testSchemaOverride *ModuleSchemaOverride
+	for _, override := range overrides {
+		if override.Source == "example-module-source-for-testing" {
+			testSchemaOverride = override
+			break
+		}
 	}
-	assert.Equal(t,
-		expectedConfigVariables,
-		awsVpcSchema.ProvidersConfig.Variables,
-		"required provider variables are incorrect")
+	assert.NotNil(t, testSchemaOverride, "test schema override is nil")
+	assert.NotNil(t, testSchemaOverride.MinimumVersion, "partial schema is nil")
+	assert.Equal(t, *testSchemaOverride.MinimumVersion, "0.1.0", "minimum version is incorrect")
+	assert.Equal(t, testSchemaOverride.MaximumVersion, "6.0.0", "maximum version is incorrect")
+	assert.NotNil(t, testSchemaOverride.PartialSchema, "partial schema is nil")
+	assert.Equal(t, testSchemaOverride.PartialSchema.Inputs, map[string]*schema.PropertySpec{
+		"example_input": {
+			Description: "An example input for the module.",
+			TypeSpec:    stringType,
+		},
+		"example_ref": {
+			TypeSpec: refType("#/types/vpc:index:MyType"),
+		},
+	})
+
+	assert.Equal(t, testSchemaOverride.PartialSchema.Outputs, map[string]*schema.PropertySpec{
+		"example_output": {
+			TypeSpec:    boolType,
+			Description: "An example output for the module.",
+		},
+	})
+
+	assert.Equal(t, testSchemaOverride.PartialSchema.SupportingTypes, map[string]*schema.ComplexTypeSpec{
+		"vpc:index:MyType": {
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Type:        "object",
+				Description: "An example supporting type for the module.",
+				Properties: map[string]schema.PropertySpec{
+					"example_property": {
+						Description: "An example property for the supporting type.",
+						TypeSpec:    stringType,
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestApplyModuleOverrides(t *testing.T) {
+	ctx := context.Background()
+	packageName := packageName("vpc")
+	version := TFModuleVersion("5.18.1")
+	source := TFModuleSource("terraform-aws-modules/vpc/aws")
+	awsVpcSchema, err := InferModuleSchema(ctx, packageName, source, version)
+	assert.NoError(t, err, "failed to infer module schema for aws vpc module")
+	assert.NotNil(t, awsVpcSchema, "inferred module schema for aws vpc module is nil")
+	// We cannot infer which outputs are required or not so everything is optional, initially.
+	assert.Empty(t, awsVpcSchema.NonNilOutputs, "required outputs is empty")
+
+	t.Run("required outputs are updated", func(t *testing.T) {
+		moduleOverrides := []*ModuleSchemaOverride{
+			{
+				Source:         string(source),
+				MaximumVersion: "6.0.0",
+				PartialSchema: &InferredModuleSchema{
+					NonNilOutputs: []string{"vpc_id"},
+				},
+			},
+		}
+
+		partialAwsVpcSchemaOverride, ok := hasBuiltinModuleSchemaOverrides(source, version, moduleOverrides)
+		assert.True(t, ok, "module schema overrides should be found")
+		overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
+		assert.NotNil(t, overridenSchema, "overriden module schema is nil")
+		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be required")
+	})
+
+	t.Run("specific fields can be updated", func(t *testing.T) {
+		moduleOverrides := []*ModuleSchemaOverride{
+			{
+				Source:         string(source),
+				MaximumVersion: "6.0.0",
+				PartialSchema: &InferredModuleSchema{
+					Outputs: map[string]*schema.PropertySpec{
+						"vpc_id": {
+							Description: "The new ID field of the VPC",
+							Secret:      true,
+						},
+					},
+				},
+			},
+		}
+
+		partialAwsVpcSchemaOverride, ok := hasBuiltinModuleSchemaOverrides(source, version, moduleOverrides)
+		assert.True(t, ok, "module schema overrides should be found")
+		overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
+		assert.NotNil(t, overridenSchema, "overriden module schema is nil")
+		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be non-nil")
+
+		vpcId := overridenSchema.Outputs["vpc_id"]
+		assert.Equal(t, "The new ID field of the VPC", vpcId.Description, "vpc_id description should be updated")
+		assert.True(t, vpcId.Secret, "vpc_id should be secret")
+		assert.Equal(t, "string", vpcId.TypeSpec.Type, "vpc_id type should not be changed")
+		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be non-nil")
+	})
+}
+
+func TestExtractModuleContentWorksFromLocalPath(t *testing.T) {
+	ctx := context.Background()
+	src := filepath.Join("..", "..", "tests", "testdata", "modules", "randmod")
+	p, err := filepath.Abs(src)
+	require.NoError(t, err)
+	logger := tfsandbox.DiscardLogger
+	mod, err := extractModuleContent(ctx, TFModuleSource(p), "", logger)
+	require.NoError(t, err)
+	require.NotNil(t, mod, "module contents should not be nil")
 }
 
 func TestInferModuleSchemaFromGitHubSource(t *testing.T) {

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -221,7 +221,7 @@ func TestApplyModuleOverrides(t *testing.T) {
 		partialAwsVpcSchemaOverride, ok := hasBuiltinModuleSchemaOverrides(source, version, moduleOverrides)
 		assert.True(t, ok, "module schema overrides should be found")
 		overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
-		assert.NotNil(t, overridenSchema, "overriden module schema is nil")
+		assert.NotNil(t, overridenSchema, "overridden module schema is nil")
 		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be required")
 	})
 
@@ -244,13 +244,13 @@ func TestApplyModuleOverrides(t *testing.T) {
 		partialAwsVpcSchemaOverride, ok := hasBuiltinModuleSchemaOverrides(source, version, moduleOverrides)
 		assert.True(t, ok, "module schema overrides should be found")
 		overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
-		assert.NotNil(t, overridenSchema, "overriden module schema is nil")
+		assert.NotNil(t, overridenSchema, "overridden module schema is nil")
 		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be non-nil")
 
-		vpcId := overridenSchema.Outputs["vpc_id"]
-		assert.Equal(t, "The new ID field of the VPC", vpcId.Description, "vpc_id description should be updated")
-		assert.True(t, vpcId.Secret, "vpc_id should be secret")
-		assert.Equal(t, "string", vpcId.TypeSpec.Type, "vpc_id type should not be changed")
+		vpcID := overridenSchema.Outputs["vpc_id"]
+		assert.Equal(t, "The new ID field of the VPC", vpcID.Description, "vpc_id description should be updated")
+		assert.True(t, vpcID.Secret, "vpc_id should be secret")
+		assert.Equal(t, "string", vpcID.TypeSpec.Type, "vpc_id type should not be changed")
 		assert.Contains(t, overridenSchema.NonNilOutputs, "vpc_id", "vpc_id should be non-nil")
 	})
 }

--- a/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
+++ b/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
@@ -1575,14 +1575,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * 
      */
     @Export(name="vpc_id", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> vpc_id;
+    private Output<String> vpc_id;
 
     /**
      * @return The ID of the VPC
      * 
      */
-    public Output<Optional<String>> vpc_id() {
-        return Codegen.optional(this.vpc_id);
+    public Output<String> vpc_id() {
+        return this.vpc_id;
     }
     /**
      * Tenancy of instances spin up within VPC

--- a/tests/testdata/aws-vpc/node/sdks/vpc/module.ts
+++ b/tests/testdata/aws-vpc/node/sdks/vpc/module.ts
@@ -468,7 +468,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * The ID of the VPC
      */
-    public /*out*/ readonly vpc_id!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_id!: pulumi.Output<string>;
     /**
      * Tenancy of instances spin up within VPC
      */


### PR DESCRIPTION
# Description

This PR addresses #70 by allow us to override inferred schema using configuration files for the following use cases:

### Schema configuration for known modules

Providing schema overrides for known modules (e.g. for top N common AWS modules), typically authored by us and added to this repository in the `pkg/modprovider/module_schema_overrides` directory. These will automatically apply for users without their intervention such that the generated SDKs have the correct types. 

> Right now, I have not started creating a catalogue of these schemas but the ability is there.

See [docs](https://github.com/pulumi/pulumi-terraform-module/blob/7e0d17ae6b56c4703db7f47e1423ce15ebc74776/pkg/modprovider/module_schema_overrides/README.md) about these known-schema config files

### Schemas configuration provided by the users

Available via `--config <path-to-config-file.json>` when using the `pulumi package add ...` as follows:

```
pulumi package add terraform-module -- <module> [<version-spec>] <pulumi-package> --config <path-to-config.json>
```

Where the config file applies schema overrides for either remote or local modules. This config file is authored by the user but can later be inferred from TF state files but that for a later stage. 

A [docs section](https://github.com/pulumi/pulumi-terraform-module/blob/9f6427ce00e6177c552e34c48c122115a4bc0515/README.md#module-configuration-and-schema-override) has been added to the README about how to use these local config files
