### PR TITLE
Refine docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ To get started, run this in the context of a Pulumi program:
 
     pulumi package add terraform-module <module> [<version-spec>] <pulumi-package>
 
-For example you can run the following to add the [VPC
-module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest) as a Pulumi
-package called "vpc":
+For example you can run the following to add the
+[VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest) as a Pulumi package
+called "vpc":
 
     pulumi package add terraform-module terraform-aws-modules/vpc/aws 5.18.1 vpc
 
-Pulumi will generate a local SDK in your current programming language and print instructions on how
-to use it. For example, if your program is in TypeScript, you can start provisioning the module as
-follows:
+Pulumi will generate a local SDK in your current programming language and print instructions on how to use it. For
+example, if your program is in TypeScript, you can start provisioning the module as follows:
 
 ``` typescript
 import * as vpc from "@pulumi/vpc";
@@ -26,8 +25,8 @@ const defaultVpc = new vpc.Module("defaultVpc", {cidr: "10.0.0.0/16"});
 
 ### Local Modules
 
-Local modules are supported. Any directory with `.tf` files and optionally `variables.tf` and
-`outputs.tf` is a module. It can be added to a Pulumi program with:
+Local modules are supported. Any directory with `.tf` files and optionally `variables.tf` and `outputs.tf` is a module.
+It can be added to a Pulumi program with:
 
     pulumi package add terraform-module <path> <pulumi-package>
 
@@ -55,9 +54,9 @@ const testBucket = new bucket.Module("test-bucket", {
 }, { provider: provider });
 ```
 
-The relevant [Provider
-Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#provider-configuration) section will
-be the right place to look for what keys can be configured.
+The relevant
+[Provider Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#provider-configuration)
+section will be the right place to look for what keys can be configured.
 
 Any environment variables you set for Pulumi execution will also be available to these providers. To continue with the
 AWS provider example, you can ensure it can authenticate by setting `AWS_PROFILE` or else `AWS_ACCESS_KEY` and similar
@@ -66,10 +65,10 @@ environment variables.
 Note that the providers powering the Module are Terraform providers and not Pulumi bridged providers such as
 [pulumi-aws](https://github.com/pulumi/pulumi-aws). They are the right place to look for additional documentation.
 
-## Usage for Pulumi YAML programs
+### Using Modules with Pulumi YAML
 
 Pulumi YAML programs do not have an SDK per se; `pulumi package add` only generates a parameterized package reference.
-To use a local module inside a Pulumi YAML program, you would reference the module by its schema token, 
+To use a local module inside a Pulumi YAML program, you would reference the module by its schema token,
 <package-name>:index:Module.
 In our VPC example this would look as follows:
 
@@ -80,6 +79,19 @@ resources:
     properties:
       [ ... ]
 ```
+
+### Fixing Incorrect Output Types
+
+Terraform modules have insufficient metadata to precisely identify the type of every module output. If Pulumi infers an
+incorrect or non-optimal type, you can override it (see
+[Config Reference](https://github.com/pulumi/pulumi-terraform-module/blob/main/docs/config-reference.md)).
+
+To override a type for a well-known module globally for all Pulumi users, consider contributing a Pull Request to edit
+a shared registry of
+[Module Schema Overrides](https://github.com/pulumi/pulumi-terraform-module/blob/main/pkg/modprovider/module_schema_overrides/README.md).
+
+There is also an [Experimental tool](https://github.com/pulumi/pulumi-tool-infer-tfmodule-schema) to use AI to generate
+better type guesses.
 
 ## How it works
 
@@ -100,6 +112,8 @@ The project is in experimental phase as we are starting to work with partners to
 preview level of maturity. There might be some breaking changes still necessary to reach our goal of of enabling as
 many Terraform modules execute seamlessly under Pulumi as possible.
 
+## Limitations
+
 Known limitations at this point include but are not limited to:
 
 - using the `transforms` resource option
@@ -111,79 +125,3 @@ Known limitations at this point include but are not limited to:
 If you are having issues, we would love to hear from you as we work to make this product better:
 
 https://github.com/pulumi/pulumi-terraform-module/issues
-
-## Module configuration and schema override
-
-When using a module, we typically infer the types of the inputs and outputs from the module code automatically. However, for the types of the outputs, we don't always get it right due to limited type information available statically. 
-
-We have added a mechanism that allows users to override the inferred schema for module with an auxiliary partial schema which is then merged with the inferred schema. This is useful when you want to provide better types inputs or outputs but only want to override a few of them, not having to fully write a schema for the module from scratch.
-
-The command you execute when you want to override the schema is:
-```
-pulumi package add terraform-module -- <module> [<version-spec>] <pulumi-package> --config <path-to-config.json>
-```
-
-Where `<path-to-config.json>` is a path to a JSON file that contains the module configuration necessary to override the inferred schema. 
-
-For example, when using the Terraform AWS VPC module, you can edit the outputs such that `default_vpc_id` is always non-nil and that is it an integer as follows:
-
-first create a file called `config.json` with the following content:
-```json
-{
-  "nonNilOutputs": ["default_vpc_id"],
-  "outputs": {
-    "default_vpc_id": {
-      "type": "integer",
-      "description": "New description ID of the default VPC"
-    }
-  }
-}
-```
-
-Then run the command:
-```
-pulumi package add terraform-module -- terraform-aws-modules/vpc/aws vpc --config config.json
-```
-
-This will add the VPC module but with the `default_vpc_id` output being an integer and non-nil. Of course, this is an example and `default_vpc_id` should be a string but you get the idea.
-
-### Overriding complex types and their references
-
-When overriding the schema, it is possible to add complex types such as objects, maps or lists and refer to them via `$ref`s. Here is a full example of how that looks like:
-
-<details>
-<summary>Full example schema</summary>
-
-```json
-"inputs": {
-    "example_input": {
-        "type": "string",
-        "description": "An example input for the module."
-    },
-    "example_ref": {
-        "$ref": "#/types/[packageName]:index:MyType"
-    }
-},
-"outputs": {
-    "example_output": {
-        "type": "boolean",
-        "description": "An example output for the module."
-    }
-},
-"requiredInputs": ["example_input"],
-"nonNilOutputs": ["example_output"],
-"supportingTypes": {
-    "[packageName]:index:MyType": {
-        "type": "object",
-        "description": "An example supporting type for the module.",
-        "properties": {
-            "example_property": {
-                "type": "string",
-                "description": "An example property for the supporting type."
-            }
-        }
-    }
-}
-```
-
-</details>

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,141 @@
+# Config Reference
+
+Terraform module behavior under Pulumi can be configured with:
+
+```
+pulumi package add terraform-module -- <module> [<version-spec>] <pulumi-package> --config <path-to-config.json>
+```
+
+## Overriding Types
+
+A key use case for config files is overriding types.
+
+When using a module, Pulumi typically infers the types of the inputs and outputs from the module code automatically.
+However the inferred type is not always correct or optimal due to limited type information available statically. This
+especially often applies to outputs. Pulumi will default to using the string type when in doubt, but outputs of complex
+types may not be usable from your program when the string type is incorrectly inferred.
+
+You can override the inferred schema for module with an auxiliary partial schema which is then merged with the inferred
+schema. The overrides will provide better types inputs.
+
+For example, when using the Terraform AWS VPC module, you can edit the outputs such that `default_vpc_id` is always
+non-nil and that is it an integer as follows (`config.json`):
+
+```json
+{
+  "nonNilOutputs": ["default_vpc_id"],
+  "outputs": {
+    "default_vpc_id": {
+      "type": "integer",
+      "description": "New description ID of the default VPC"
+    }
+  }
+}
+```
+
+Re-run the command for the changes to take effect:
+
+```
+pulumi package add terraform-module -- terraform-aws-modules/vpc/aws vpc --config config.json
+```
+
+This will add the VPC module but with the `default_vpc_id` output being an integer and non-nil.
+
+### Specifying Array and Map Types
+
+Following Pulumi Package Schema, array types are specified like this:
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}
+```
+
+And map types like this:
+
+```json
+{
+  "type": "object",
+  "additinalProperties": {
+    "type": "string"
+  }
+}
+```
+
+
+### Specifying Complex Types with References
+
+Complex object types require additional `supportingType` entries and `$ref` references, for example:
+
+<details>
+<summary>Full example schema</summary>
+
+```json
+"inputs": {
+    "example_input": {
+        "type": "string",
+        "description": "An example input for the module."
+    },
+    "example_ref": {
+        "$ref": "#/types/[packageName]:index:MyType"
+    }
+},
+"outputs": {
+    "example_output": {
+        "type": "boolean",
+        "description": "An example output for the module."
+    }
+},
+"requiredInputs": ["example_input"],
+"nonNilOutputs": ["example_output"],
+"supportingTypes": {
+    "[packageName]:index:MyType": {
+        "type": "object",
+        "description": "An example supporting type for the module.",
+        "properties": {
+            "example_property": {
+                "type": "string",
+                "description": "An example property for the supporting type."
+            }
+        }
+    }
+}
+```
+
+</details>
+
+## Configuration File Schema
+
+Note that configuration file reuses grammar elements from the [Pulumi Package
+Schema](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/schema/).
+
+### outputs
+
+Map of property names to [Property](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/schema/#property)
+specifications that override the automatically inferred schema for a particular module output.
+
+### nonNilOutputs
+
+List of module output names that should never be nullable in Pulumi, but instead can always be assumed to be populated
+by the module. Overrides the default decision.
+
+### inputs
+
+Map of property names to [Property](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/schema/#property)
+specifications that override the automatically inferred schema for a particular module input. While typically inputs
+have more metadata available and have better types inferred by default, it is occasionally useful to refine the Pulumi
+type for a module input as well.
+
+### requiredInputs
+
+List of module input names that should be always set by the caller. This will inform language SDK generation to
+generate non-optional types for these in Pulumi if the target language supports this.
+
+### supportingTypes
+
+A token-indexed map of types [Type](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/schema/#type) that
+permits registering additional types such as complex nested object types with Pulumi for use in `inputs` or `outputs`
+configuration.


### PR DESCRIPTION
Shortened the top-level README by moving config reference under docs.

Linked the override registry from top-level README.

Linked the experimental tool.

Added links to Pulumi Package Schema to the config reference.