### PR TITLE
Unwrap secreted configs in cleanProvidersConfig

### DIFF
--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -394,6 +394,24 @@ func cleanProvidersConfig(config resource.PropertyMap) map[string]resource.Prope
 			providersConfig[string(propertyKey)] = serializedConfig.ObjectValue()
 			continue
 		}
+		if serializedConfig.IsSecret() {
+			// When a provider passes in terraformConfig.Result from a previously configured provider,
+			// that result is a resource.PropertyValue wrapped in a secret.
+			// Unwrap this secret and parse the JSON string inside it.
+			secretValue := serializedConfig.SecretValue().Element
+			if secretValue.IsString() {
+				value := secretValue.StringValue()
+				deserialized := map[string]interface{}{}
+				if err := json.Unmarshal([]byte(value), &deserialized); err != nil {
+					contract.Failf("failed to deserialize provider config from secret into a map: %v", err)
+				}
+
+				if len(deserialized) > 0 {
+					providersConfig[string(propertyKey)] = resource.NewPropertyMapFromMap(deserialized)
+				}
+			}
+			continue
+		}
 
 		contract.Failf("cleanProvidersConfig failed to parse unsupported type: %v", serializedConfig)
 	}
@@ -413,6 +431,7 @@ func (s *server) Construct(
 	})
 
 	providersConfig := cleanProvidersConfig(s.providerConfig)
+
 	if err != nil {
 		return nil, fmt.Errorf("Construct failed to parse inputs: %s", err)
 	}

--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -23,6 +23,9 @@ import (
 	"io/fs"
 	"os"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/ryboe/q"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -30,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -398,7 +400,19 @@ func cleanProvidersConfig(config resource.PropertyMap) map[string]resource.Prope
 			// When a provider passes in terraformConfig.Result from a previously configured provider,
 			// that result is a resource.PropertyValue wrapped in a secret.
 			// Unwrap this secret and return the underlying object.
-			providersConfig[string(propertyKey)] = resource.NewPropertyMap(serializedConfig.SecretValue())
+			secret := serializedConfig.SecretValue()
+			if secret.Element.IsString() {
+				value := secret.Element.StringValue()
+				deserialized := map[string]interface{}{}
+				if err := json.Unmarshal([]byte(value), &deserialized); err != nil {
+					contract.Failf("failed to deserialize secret provider config into a map: %v", err)
+				}
+				if len(deserialized) > 0 {
+					providersConfig[string(propertyKey)] = resource.NewPropertyMapFromMap(deserialized)
+				}
+			} else {
+				providersConfig[string(propertyKey)] = resource.NewPropertyMap(secret.Element)
+			}
 			continue
 		}
 
@@ -406,6 +420,26 @@ func cleanProvidersConfig(config resource.PropertyMap) map[string]resource.Prope
 	}
 
 	return providersConfig
+}
+
+func unSecretProvidersConfig(config resource.PropertyMap) resource.PropertyMap {
+	q.Q(config)
+
+	guinsConfig := make(map[string]resource.PropertyMap)
+
+	for propertyKey, propertyValue := range config {
+		if propertyValue.IsSecret() {
+			// When a provider passes in terraformConfig.Result from a previously configured provider,
+			// that result is a resource.PropertyValue wrapped in a secret.
+			// Unwrap this secret and return the underlying object.
+			guinsConfig[string(propertyKey)] = resource.NewPropertyMap(propertyValue.SecretValue())
+		} else {
+			guinsConfig[string(propertyKey)] = resource.NewPropertyMap(propertyValue)
+		}
+	}
+	q.Q(guinsConfig)
+	return resource.NewPropertyMap(guinsConfig)
+
 }
 
 func (s *server) Construct(
@@ -418,6 +452,23 @@ func (s *server) Construct(
 		KeepResources:    true,
 		KeepOutputValues: true,
 	})
+
+	// Check if config has secrets
+	//guinsConfig := make(map[string]resource.PropertyMap)
+	//
+	//for propertyKey, propertyValue := range s.providerConfig {
+	//	if propertyValue.IsSecret() {
+	//		// When a provider passes in terraformConfig.Result from a previously configured provider,
+	//		// that result is a resource.PropertyValue wrapped in a secret.
+	//		// Unwrap this secret and return the underlying object.
+	//		guinsConfig[string(propertyKey)] = resource.NewPropertyMap(propertyValue.SecretValue())
+	//		continue
+	//	}
+	//}
+	//
+	//
+	//
+	//q.Q(guinsConfig)
 
 	providersConfig := cleanProvidersConfig(s.providerConfig)
 	if err != nil {

--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -23,7 +23,6 @@ import (
 	"io/fs"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -31,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"

--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -382,17 +382,22 @@ func Test_cleanProvidersConfigUnwrapsSecrets(t *testing.T) {
 	inputConfig := resource.PropertyMap{
 		"aws": resource.PropertyValue{
 			V: &resource.Secret{
-				Element: resource.NewStringProperty(`{"region":"us-west-2"}`),
+				Element: resource.PropertyValue{
+					V: `{"region":"us-west-2"}`,
+				},
 			},
 		},
-		"version": resource.NewStringProperty("0.0.0-alpha.0+dev"),
+		"version": resource.PropertyValue{
+			V: "0.0.0-alpha.0+dev",
+		},
 	}
-
 	cleaned := cleanProvidersConfig(inputConfig)
 	expected := map[string]resource.PropertyMap{
-		"aws": {
-			"region": resource.NewStringProperty("us-west-2"),
-		},
+		"aws": resource.NewPropertyMap(&resource.Secret{
+			Element: resource.PropertyValue{
+				V: `{"region":"us-west-2"}`,
+			},
+		}),
 	}
 	assert.Equal(t, expected, cleaned)
 }

--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -377,3 +377,22 @@ func Test_cleanProvidersConfig(t *testing.T) {
 
 	assert.Equal(t, expected, cleaned)
 }
+
+func Test_cleanProvidersConfigUnwrapsSecrets(t *testing.T) {
+	inputConfig := resource.PropertyMap{
+		"aws": resource.PropertyValue{
+			V: &resource.Secret{
+				Element: resource.NewStringProperty(`{"region":"us-west-2"}`),
+			},
+		},
+		"version": resource.NewStringProperty("0.0.0-alpha.0+dev"),
+	}
+
+	cleaned := cleanProvidersConfig(inputConfig)
+	expected := map[string]resource.PropertyMap{
+		"aws": {
+			"region": resource.NewStringProperty("us-west-2"),
+		},
+	}
+	assert.Equal(t, expected, cleaned)
+}

--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/ryboe/q"
 )
 
 func TestParseParameterizeRequest(t *testing.T) {
@@ -393,11 +394,10 @@ func Test_cleanProvidersConfigUnwrapsSecrets(t *testing.T) {
 	}
 	cleaned := cleanProvidersConfig(inputConfig)
 	expected := map[string]resource.PropertyMap{
-		"aws": resource.NewPropertyMap(&resource.Secret{
-			Element: resource.PropertyValue{
-				V: `{"region":"us-west-2"}`,
-			},
+		"aws": resource.NewPropertyMapFromMap(map[string]interface{}{
+			"region": "us-west-2",
 		}),
 	}
+	q.Q(expected, cleaned)
 	assert.Equal(t, expected, cleaned)
 }


### PR DESCRIPTION
This pull request adds the ability to unwrap a secreted config value in cleanProvidersConfig.

Currently, a config object wrapped in a secret would fail as an unsupported type. But part of the logic in https://github.com/pulumi/pulumi-terraform-bridge/pull/3007 wraps the `terraformConfig().return` object in a secret. This object is already properly formatted to be usable by Terraform; so all we need to do is return the secret's value.

A potential concern is that any user-provided secret config inputs would also hit this line, and perhaps not get cleaned up properly. I'm not sure how much of a concern that should be - the alternative is running two separate passes over `s.providerConfig`.

Prerequisite for https://github.com/pulumi/pulumi-terraform-bridge/pull/3007 .