### PR TITLE
Simpler workdir cleanup

### DIFF
--- a/pkg/modprovider/helpers_test.go
+++ b/pkg/modprovider/helpers_test.go
@@ -15,7 +15,7 @@ import (
 func newTestTofu(t *testing.T) *tfsandbox.Tofu {
 	srv := newTestAuxProviderServer(t)
 
-	tofu, err := tfsandbox.NewTofu(context.Background(), nil, srv)
+	tofu, err := tfsandbox.NewTofu(context.Background(), tfsandbox.DiscardLogger, nil, srv)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/modprovider/logger.go
+++ b/pkg/modprovider/logger.go
@@ -109,6 +109,8 @@ func (l *resourceLogger) Log(ctx context.Context, level tfsandbox.LogLevel, mess
 	var err error
 	var diagLevel diag.Severity
 	switch level {
+	case tfsandbox.Debug:
+		diagLevel = diag.Debug
 	case tfsandbox.Info:
 		diagLevel = diag.Info
 	case tfsandbox.Warn:

--- a/pkg/modprovider/module_component.go
+++ b/pkg/modprovider/module_component.go
@@ -129,7 +129,9 @@ func newModuleComponentResource(
 	}()
 
 	wd := tfsandbox.ModuleInstanceWorkdir(urn)
-	tf, err := tfsandbox.NewTofu(ctx.Context(), wd, auxProviderServer)
+	logger := newComponentLogger(ctx.Log, &component)
+
+	tf, err := tfsandbox.NewTofu(ctx.Context(), logger, wd, auxProviderServer)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Sandbox construction failed: %w", err)
 	}
@@ -160,8 +162,6 @@ func newModuleComponentResource(
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
-
-	logger := newComponentLogger(ctx.Log, &component)
 
 	err = tf.Init(ctx.Context(), logger)
 	if err != nil {

--- a/pkg/modprovider/state.go
+++ b/pkg/modprovider/state.go
@@ -260,7 +260,9 @@ func (h *moduleStateHandler) Delete(
 
 	wd := tfsandbox.ModuleInstanceWorkdir(urn)
 
-	tf, err := tfsandbox.NewTofu(ctx, wd, h.auxProviderServer)
+	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
+
+	tf, err := tfsandbox.NewTofu(ctx, logger, wd, h.auxProviderServer)
 	if err != nil {
 		return nil, fmt.Errorf("Sandbox construction failed: %w", err)
 	}
@@ -298,8 +300,6 @@ func (h *moduleStateHandler) Delete(
 	if err != nil {
 		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
-
-	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
 
 	err = tf.Init(ctx, logger)
 	if err != nil {
@@ -339,7 +339,9 @@ func (h *moduleStateHandler) Read(
 	tfName := getModuleName(modUrn)
 	wd := tfsandbox.ModuleInstanceWorkdir(modUrn)
 
-	tf, err := tfsandbox.NewTofu(ctx, wd, h.auxProviderServer)
+	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
+
+	tf, err := tfsandbox.NewTofu(ctx, logger, wd, h.auxProviderServer)
 	if err != nil {
 		return nil, fmt.Errorf("Sandbox construction failed: %w", err)
 	}
@@ -362,8 +364,6 @@ func (h *moduleStateHandler) Read(
 	if err != nil {
 		return nil, fmt.Errorf("PushStateAndLockFile failed: %w", err)
 	}
-
-	logger := newResourceLogger(h.hc, resource.URN(req.GetUrn()))
 
 	plan, err := tf.PlanRefreshOnly(ctx, logger)
 	if err != nil {

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -611,7 +611,7 @@ func resolveModuleSources(
 	logger tfsandbox.Logger,
 	auxServer *auxprovider.Server,
 ) (string, error) {
-	tf, err := tfsandbox.NewTofu(ctx, tfsandbox.ModuleWorkdir(source, version), auxServer)
+	tf, err := tfsandbox.NewTofu(ctx, logger, tfsandbox.ModuleWorkdir(source, version), auxServer)
 	if err != nil {
 		return "", fmt.Errorf("tofu sandbox construction failure: %w", err)
 	}

--- a/pkg/tfsandbox/helpers_test.go
+++ b/pkg/tfsandbox/helpers_test.go
@@ -13,7 +13,7 @@ import (
 func newTestTofu(t *testing.T) *Tofu {
 	srv := newTestAuxProviderServer(t)
 
-	tofu, err := NewTofu(context.Background(), nil, srv)
+	tofu, err := NewTofu(context.Background(), DiscardLogger, nil, srv)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/tfsandbox/plan.go
+++ b/pkg/tfsandbox/plan.go
@@ -59,7 +59,7 @@ func (t *Tofu) planRefreshOnly(ctx context.Context, logger Logger) (*tfjson.Plan
 }
 
 func (t *Tofu) planWithOptions(ctx context.Context, logger Logger, refreshOnly bool) (*tfjson.Plan, error) {
-	planFile := path.Join(t.WorkingDir(), "plan.out")
+	planFile := path.Join(t.WorkingDir(), defaultPlanFile)
 	logWriter := newJSONLogPipe(ctx, logger)
 	defer logWriter.Close()
 	_ /*hasChanges*/, err := t.tf.PlanJSON(ctx, logWriter,

--- a/pkg/tfsandbox/state.go
+++ b/pkg/tfsandbox/state.go
@@ -22,8 +22,11 @@ import (
 	"path/filepath"
 )
 
-const defaultStateFile = "terraform.tfstate"
-const defaultLockFile = ".terraform.lock.hcl"
+const (
+	defaultStateFile = "terraform.tfstate"
+	defaultLockFile  = ".terraform.lock.hcl"
+	defaultPlanFile  = "plan.out"
+)
 
 // PullStateAndLockFile reads the state and lock file from the Tofu working directory.
 // If the lock file is not present, it returns nil for the lock file and no error.

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -21,6 +21,7 @@ const (
 	unknownProxyResourceName       = "unknown_proxy"
 	unknownProxyResourceOutputProp = "value"
 	terraformIsSecretOutputPrefix  = "internal_output_is_secret_"
+	pulumiTFJsonFileName           = "pulumi.tf.json"
 )
 
 func writeTerraformFilesToDirectory() (string, bool) {
@@ -249,7 +250,7 @@ func CreateTFFile(
 		return err
 	}
 
-	if err := os.WriteFile(path.Join(workingDir, "pulumi.tf.json"), contents, 0600); err != nil {
+	if err := os.WriteFile(path.Join(workingDir, pulumiTFJsonFileName), contents, 0600); err != nil {
 		return err
 	}
 

--- a/pkg/tfsandbox/tf_file_test.go
+++ b/pkg/tfsandbox/tf_file_test.go
@@ -261,7 +261,7 @@ func TestCreateTFFile(t *testing.T) {
 			}, tt.outputs, tt.providersConfig)
 			assert.NoError(t, err)
 
-			contents, err := os.ReadFile(filepath.Join(tofu.WorkingDir(), "pulumi.tf.json"))
+			contents, err := os.ReadFile(filepath.Join(tofu.WorkingDir(), pulumiTFJsonFileName))
 			assert.NoError(t, err)
 			t.Logf("Contents: %s", string(contents))
 

--- a/pkg/tfsandbox/tofu.go
+++ b/pkg/tfsandbox/tofu.go
@@ -93,7 +93,7 @@ func (t *Tofu) WorkingDir() string {
 
 // NewTofu will create a new Tofu client which can be used to
 // programmatically interact with the tofu cli
-func NewTofu(ctx context.Context, workdir Workdir, auxServer *auxprovider.Server) (*Tofu, error) {
+func NewTofu(ctx context.Context, logger Logger, workdir Workdir, auxServer *auxprovider.Server) (*Tofu, error) {
 	// This is only used for testing.
 	if workdir == nil {
 		workdir = Workdir([]string{
@@ -106,7 +106,7 @@ func NewTofu(ctx context.Context, workdir Workdir, auxServer *auxprovider.Server
 		return nil, fmt.Errorf("error downloading tofu: %w", err)
 	}
 
-	workDir, err := workdirGetOrCreate(workdir)
+	workDir, err := workdirGetOrCreate(ctx, logger, workdir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfsandbox/workdir.go
+++ b/pkg/tfsandbox/workdir.go
@@ -15,6 +15,8 @@
 package tfsandbox
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -45,16 +47,18 @@ func ModuleWorkdir(source TFModuleSource, version TFModuleVersion) Workdir {
 // Get or create a folder under $TMPDIR matching the current Pulumi project and stack.
 //
 // If the folder exists, clean it up except for expensive assets (see [workdirClean]).
-func workdirGetOrCreate(workdir Workdir) (string, error) {
+func workdirGetOrCreate(ctx context.Context, logger Logger, workdir Workdir) (string, error) {
 	path := workdirPath(workdir)
 
 	if dirExists(path) {
+		logger.Log(ctx, Debug, fmt.Sprintf("Reusing working directory: %s", path))
 		if err := workdirClean(path); err != nil {
 			return "", err
 		}
 		return path, nil
 	}
 
+	logger.Log(ctx, Debug, fmt.Sprintf("Creating working directory: %s", path))
 	if err := os.MkdirAll(path, 0700); err != nil {
 		return "", fmt.Errorf("Error creating workdir %q: %v", path, err)
 	}
@@ -62,57 +66,40 @@ func workdirGetOrCreate(workdir Workdir) (string, error) {
 	return path, nil
 }
 
-// Delete all files to guarantee a fresh start, with the following exceptions:
+// Delete all transient files to avoid accidentally poisoning accuracy of TOFU execution with stale files.
+//
+// While not listed in an explicit way, the following important sub-paths with persist across `pulumi` executions as
+// they are not part of the cleanup:
 //
 // .terraform/modules    are kept as a local cache to speed up resolution
 // .terraform/providers  are kept as a local cache to speed up resolution
-// .terraform.lock.hcl   produced by tofu init is kept around
+//
+// Some modules such as https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws/latest manage
+// additional sub-paths such as "builds" (see variable "artifacts_dir") and expect them to persist across invocations.
 func workdirClean(workdir string) error {
-	entries, err := os.ReadDir(workdir)
-	if err != nil {
-		return fmt.Errorf("Error cleaning workdir %q: %w", workdir, err)
+	var errs []error
+
+	for _, p := range []string{
+		// JSON HCL configs are rewritten on each interaction and should not persist across runs.
+		filepath.Join(workdir, pulumiTFJsonFileName),
+
+		// Default state files are injected on each interaction to match Pulumi-tracked state.
+		filepath.Join(workdir, defaultStateFile),
+
+		// This project uses a temp path for plan files; these are recomputed on demand, do not persist.
+		filepath.Join(workdir, defaultPlanFile),
+
+		// This project always rewrites the lockfile as it is stored in the Pulumi state. Avoid accidental
+		// reuse from the cache. In case of creating from scratch this is moot and it will be recomputed.
+		filepath.Join(workdir, defaultLockFile),
+	} {
+		if err := os.RemoveAll(p); err != nil {
+			errs = append(errs, fmt.Errorf("Error cleaning %q: %w", p, err))
+		}
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() && entry.Name() == ".terraform" {
-			err := workdirCleanDotTerraform(workdir)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-
-		if !entry.IsDir() && entry.Name() == ".terraform.lock.hcl" {
-			continue
-		}
-
-		sub := filepath.Join(workdir, entry.Name())
-		if err := os.RemoveAll(sub); err != nil {
-			return fmt.Errorf("Error cleaning workdir path %q: %w", sub, err)
-		}
-	}
-	return nil
-}
-
-// See [workdirClean].
-func workdirCleanDotTerraform(workdir string) error {
-	td := filepath.Join(workdir, ".terraform")
-	tfEntries, err := os.ReadDir(td)
-	if err != nil {
-		return fmt.Errorf("Error cleaning workdir .terraform dir %q: %w", workdir, err)
-	}
-
-	for _, tfEntry := range tfEntries {
-		if tfEntry.IsDir() && tfEntry.Name() == "providers" {
-			continue
-		}
-		if tfEntry.IsDir() && tfEntry.Name() == "modules" {
-			continue
-		}
-		sub := filepath.Join(td, tfEntry.Name())
-		if err := os.RemoveAll(sub); err != nil {
-			return fmt.Errorf("Error cleaning .terraform path %q: %w", sub, err)
-		}
+	if err := errors.Join(errs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/tfsandbox/workdir_test.go
+++ b/pkg/tfsandbox/workdir_test.go
@@ -68,22 +68,24 @@ func Test_workdirGetOrCreate(t *testing.T) {
 	err = os.WriteFile(filepath.Join(p, ".terraform", "providers", "p1"), []byte(`p1`), 0600)
 	require.NoError(t, err)
 
-	p2, err := workdirGetOrCreate(ctx, DiscardLogger, wd)
+	p2, err := workdirGetOrCreate(ctx, &testLogger{os.Stdout}, wd)
 	require.NoError(t, err)
 
 	assert.True(t, dirExists(p2))
 
-	_, err = os.Stat(filepath.Join(p, "infra.tf"))
-	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(p, pulumiTFJsonFileName))
+	require.Truef(t, os.IsNotExist(err), "expected the source file to be cleaned up")
+
+	_, err = os.Stat(filepath.Join(p, defaultLockFile))
+	require.Truef(t, os.IsNotExist(err), "expected the lock file to be cleaned up")
 
 	existingFiles := []string{
-		filepath.Join(p, defaultLockFile),
 		filepath.Join(p, ".terraform", "modules", "m1"),
 		filepath.Join(p, ".terraform", "providers", "p1"),
 	}
 
 	for _, f := range existingFiles {
 		_, err = os.Stat(f)
-		require.NoError(t, err)
+		require.NoErrorf(t, err, "expected %q to continue existing", f)
 	}
 }

--- a/pkg/tfsandbox/workdir_test.go
+++ b/pkg/tfsandbox/workdir_test.go
@@ -15,6 +15,7 @@
 package tfsandbox
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,17 +38,19 @@ func Test_ModuleWorkdir(t *testing.T) {
 }
 
 func Test_workdirGetOrCreate(t *testing.T) {
+	ctx := context.Background()
+
 	wd := ModuleWorkdir("my-module", "")
 
 	err := os.RemoveAll(workdirPath(wd))
 	require.NoError(t, err)
 
-	p, err := workdirGetOrCreate(wd)
+	p, err := workdirGetOrCreate(ctx, DiscardLogger, wd)
 	require.NoError(t, err)
 
 	assert.True(t, dirExists(p))
 
-	err = os.WriteFile(filepath.Join(p, ".terraform.lock.hcl"), []byte(`LOCK`), 0600)
+	err = os.WriteFile(filepath.Join(p, defaultLockFile), []byte(`LOCK`), 0600)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(p, "infra.tf"), []byte(`INFRA`), 0600)
@@ -65,7 +68,7 @@ func Test_workdirGetOrCreate(t *testing.T) {
 	err = os.WriteFile(filepath.Join(p, ".terraform", "providers", "p1"), []byte(`p1`), 0600)
 	require.NoError(t, err)
 
-	p2, err := workdirGetOrCreate(wd)
+	p2, err := workdirGetOrCreate(ctx, DiscardLogger, wd)
 	require.NoError(t, err)
 
 	assert.True(t, dirExists(p2))
@@ -74,7 +77,7 @@ func Test_workdirGetOrCreate(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	existingFiles := []string{
-		filepath.Join(p, ".terraform.lock.hcl"),
+		filepath.Join(p, defaultLockFile),
 		filepath.Join(p, ".terraform", "modules", "m1"),
 		filepath.Join(p, ".terraform", "providers", "p1"),
 	}

--- a/pkg/tfsandbox/workdir_test.go
+++ b/pkg/tfsandbox/workdir_test.go
@@ -76,10 +76,8 @@ func Test_workdirGetOrCreate(t *testing.T) {
 	_, err = os.Stat(filepath.Join(p, pulumiTFJsonFileName))
 	require.Truef(t, os.IsNotExist(err), "expected the source file to be cleaned up")
 
-	_, err = os.Stat(filepath.Join(p, defaultLockFile))
-	require.Truef(t, os.IsNotExist(err), "expected the lock file to be cleaned up")
-
 	existingFiles := []string{
+		filepath.Join(p, defaultLockFile),
 		filepath.Join(p, ".terraform", "modules", "m1"),
 		filepath.Join(p, ".terraform", "providers", "p1"),
 	}

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -514,10 +514,9 @@ func TestE2eTs(t *testing.T) {
 			deleteExpect: map[string]int{
 				"delete": 9,
 			},
-			// TODO: [Fix delete-replace on null_resource](https://github.com/pulumi/pulumi-terraform-module/issues/166)
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("replace"): 1,
-				apitype.OpType("same"):    8,
+				apitype.OpType("update"): 1,
+				apitype.OpType("same"):   8,
 			},
 		},
 		{

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -104,6 +104,11 @@ func Test_AlbExample(t *testing.T) {
 	)
 
 	resourceDiffs := runPreviewWithPlanDiff(t, integrationTest, "module.test-lambda.null_resource.archive[0]")
+
+	// Ignore source_code_hash as it is unstable across dev machines and CI.
+	fn := "module.test-lambda.aws_lambda_function.this[0]"
+	resourceDiffs[fn].(map[string]any)["diff"].(apitype.PlanDiffV1).Updates["source_code_hash"] = "*"
+
 	autogold.Expect(map[string]interface{}{"module.test-lambda.aws_lambda_function.this[0]": map[string]interface{}{
 		"diff": apitype.PlanDiffV1{
 			Adds: map[string]interface{}{"layers": []interface{}{}},
@@ -111,7 +116,7 @@ func Test_AlbExample(t *testing.T) {
 				"last_modified":        "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
 				"qualified_arn":        "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
 				"qualified_invoke_arn": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
-				"source_code_hash":     "+aWOA8Qvj34VoPjdEfrYc83idT+CZWFMZ800DBJccFA=",
+				"source_code_hash":     "*",
 				"version":              "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
 			},
 		},

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func Test_RdsExample(t *testing.T) {
@@ -103,5 +104,17 @@ func Test_AlbExample(t *testing.T) {
 	)
 
 	resourceDiffs := runPreviewWithPlanDiff(t, integrationTest, "module.test-lambda.null_resource.archive[0]")
-	autogold.Expect(map[string]any{}).Equal(t, resourceDiffs)
+	autogold.Expect(map[string]interface{}{"module.test-lambda.aws_lambda_function.this[0]": map[string]interface{}{
+		"diff": apitype.PlanDiffV1{
+			Adds: map[string]interface{}{"layers": []interface{}{}},
+			Updates: map[string]interface{}{
+				"last_modified":        "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				"qualified_arn":        "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				"qualified_invoke_arn": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				"source_code_hash":     "+aWOA8Qvj34VoPjdEfrYc83idT+CZWFMZ800DBJccFA=",
+				"version":              "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+			},
+		},
+		"steps": []apitype.OpType{apitype.OpType("update")},
+	}}).Equal(t, resourceDiffs)
 }

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -102,7 +102,6 @@ func Test_AlbExample(t *testing.T) {
 		optup.ProgressStreams(os.Stdout),
 	)
 
-	// TODO[pulumi/pulumi-terraform-module#166] null-resource will always show a diff
 	resourceDiffs := runPreviewWithPlanDiff(t, integrationTest, "module.test-lambda.null_resource.archive[0]")
 	autogold.Expect(map[string]any{}).Equal(t, resourceDiffs)
 }

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -15,7 +15,7 @@ import (
 func newTestTofu(t *testing.T) *tfsandbox.Tofu {
 	srv := newTestAuxProviderServer(t)
 
-	tofu, err := tfsandbox.NewTofu(context.Background(), nil, srv)
+	tofu, err := tfsandbox.NewTofu(context.Background(), tfsandbox.DiscardLogger, nil, srv)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
Workspace files are retained across `pulumi up`  invocations, matching the expectation of modules such as the AWS Lambda Terraform Module to be able to persist information in the file system across invocations. 

Fixes #166 

As a side fix, DEBUG level logs no longer show through the product UI by default. This seems to have been an unintentional omission to send them at INFO level.