### PR TITLE
Add initial list of module schema overrides

### DIFF
--- a/pkg/modprovider/module_schema_overrides/cloudposse-label.json
+++ b/pkg/modprovider/module_schema_overrides/cloudposse-label.json
@@ -1,0 +1,62 @@
+{
+    "source": "cloudposse/label/null",
+    "maximumVersion": "1.0.0",
+    "partialSchema": {
+      "outputs": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "additional_tag_map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "label_order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regex_replace_chars": {
+          "type": "string"
+        },
+        "id_length_limit": {
+          "type": "number"
+        },
+        "tags_as_list_of_maps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "descriptors": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "normalized_context": {
+          "$ref": "pulumi.json#/Any"
+        },
+        "context": {
+          "$ref": "pulumi.json#/Any"
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-acm.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-acm.json
@@ -1,0 +1,44 @@
+{
+    "source": "terraform-aws-modules/acm/aws",
+    "maximumVersion": "6.0.0",
+    "partialSchema": {
+        "outputs": {
+            "acm_certificate_domain_validation_options": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    }
+                }
+            },
+            "acm_certificate_validation_emails": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "distinct_domain_names": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "validation_domains": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    }
+                }
+            },
+            "validation_route53_record_fqdns": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-alb.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-alb.json
@@ -1,0 +1,32 @@
+{
+  "source": "terraform-aws-modules/alb/aws",
+  "maximumVersion": "10.0.0",
+  "partialSchema": {
+    "outputs": {
+      "listeners": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "listener_rules": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "target_groups": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "route53_records": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      }
+    }
+  }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-eks.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-eks.json
@@ -1,0 +1,155 @@
+{
+    "source": "terraform-aws-modules/eks/aws",
+    "maximumVersion": "21.0.0",
+    "partialSchema": {
+      "outputs": {
+        "cluster_arn": {
+          "type": "string"
+        },
+        "cluster_certificate_authority_data": {
+          "type": "string"
+        },
+        "cluster_endpoint": {
+          "type": "string"
+        },
+        "cluster_id": {
+          "type": "string"
+        },
+        "cluster_name": {
+          "type": "string"
+        },
+        "cluster_oidc_issuer_url": {
+          "type": "string"
+        },
+        "cluster_dualstack_oidc_issuer_url": {
+          "type": "string"
+        },
+        "cluster_version": {
+          "type": "string"
+        },
+        "cluster_platform_version": {
+          "type": "string"
+        },
+        "cluster_status": {
+          "type": "string"
+        },
+        "cluster_primary_security_group_id": {
+          "type": "string"
+        },
+        "cluster_service_cidr": {
+          "type": "string"
+        },
+        "cluster_ip_family": {
+          "type": "string"
+        },
+        "access_entries": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "access_policy_associations": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "kms_key_arn": {
+          "type": "string"
+        },
+        "kms_key_id": {
+          "type": "string"
+        },
+        "kms_key_policy": {
+          "type": "string"
+        },
+        "cluster_security_group_arn": {
+          "type": "string"
+        },
+        "cluster_security_group_id": {
+          "type": "string"
+        },
+        "node_security_group_arn": {
+          "type": "string"
+        },
+        "node_security_group_id": {
+          "type": "string"
+        },
+        "oidc_provider": {
+          "type": "string"
+        },
+        "oidc_provider_arn": {
+          "type": "string"
+        },
+        "cluster_tls_certificate_sha1_fingerprint": {
+          "type": "string"
+        },
+        "cluster_iam_role_name": {
+          "type": "string"
+        },
+        "cluster_iam_role_arn": {
+          "type": "string"
+        },
+        "cluster_iam_role_unique_id": {
+          "type": "string"
+        },
+        "node_iam_role_name": {
+          "type": "string"
+        },
+        "node_iam_role_arn": {
+          "type": "string"
+        },
+        "node_iam_role_unique_id": {
+          "type": "string"
+        },
+        "cluster_addons": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "cluster_identity_providers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "cloudwatch_log_group_name": {
+          "type": "string"
+        },
+        "cloudwatch_log_group_arn": {
+          "type": "string"
+        },
+        "fargate_profiles": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "eks_managed_node_groups": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "eks_managed_node_groups_autoscaling_group_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "self_managed_node_groups": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "self_managed_node_groups_autoscaling_group_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-kms.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-kms.json
@@ -1,0 +1,38 @@
+{
+    "source": "terraform-aws-modules/kms/aws",
+    "maximumVersion": "4.0.0",
+    "partialSchema": {
+      "outputs": {
+        "key_arn": {
+          "type": "string"
+        },
+        "key_id": {
+          "type": "string"
+        },
+        "key_policy": {
+          "type": "string"
+        },
+        "external_key_expiration_model": {
+          "type": "string"
+        },
+        "external_key_state": {
+          "type": "string"
+        },
+        "external_key_usage": {
+          "type": "string"
+        },
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "grants": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-rds-aurora.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-rds-aurora.json
@@ -1,0 +1,89 @@
+{
+    "source": "terraform-aws-modules/rds-aurora/aws",
+    "maximumVersion": "10.0.0",
+    "partialSchema": {
+      "outputs": {
+        "cluster_members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cluster_port": {
+          "type": "number"
+        },
+        "cluster_master_password": {
+          "type": "string"
+        },
+        "cluster_master_username": {
+          "type": "string"
+        },
+        "cluster_master_user_secret": {
+          "type": "string"
+        },
+        "cluster_hosted_zone_id": {
+          "type": "string"
+        },
+        "cluster_ca_certificate_identifier": {
+          "type": "string"
+        },
+        "cluster_ca_certificate_valid_till": {
+          "type": "string"
+        },
+        "cluster_instances": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "additional_cluster_endpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "cluster_role_associations": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "enhanced_monitoring_iam_role_name": {
+          "type": "string"
+        },
+        "enhanced_monitoring_iam_role_arn": {
+          "type": "string"
+        },
+        "enhanced_monitoring_iam_role_unique_id": {
+          "type": "string"
+        },
+        "security_group_id": {
+          "type": "string"
+        },
+        "db_cluster_parameter_group_arn": {
+          "type": "string"
+        },
+        "db_cluster_parameter_group_id": {
+          "type": "string"
+        },
+        "db_parameter_group_arn": {
+          "type": "string"
+        },
+        "db_parameter_group_id": {
+          "type": "string"
+        },
+        "db_cluster_cloudwatch_log_groups": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "db_cluster_activity_stream_kinesis_stream_name": {
+          "type": "string"
+        },
+        "db_cluster_secretsmanager_secret_rotation_enabled": {
+          "type": "boolean"
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-rds.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-rds.json
@@ -1,0 +1,92 @@
+{
+    "source": "terraform-aws-modules/rds/aws",
+    "maximumVersion": "7.0.0",
+    "partialSchema": {
+      "outputs": {
+        "enhanced_monitoring_iam_role_name": {
+          "type": "string"
+        },
+        "enhanced_monitoring_iam_role_arn": {
+          "type": "string"
+        },
+        "db_instance_address": {
+          "type": "string"
+        },
+        "db_instance_arn": {
+          "type": "string"
+        },
+        "db_instance_availability_zone": {
+          "type": "string"
+        },
+        "db_instance_endpoint": {
+          "type": "string"
+        },
+        "db_listener_endpoint": {
+          "type": "string"
+        },
+        "db_instance_engine": {
+          "type": "string"
+        },
+        "db_instance_engine_version_actual": {
+          "type": "string"
+        },
+        "db_instance_hosted_zone_id": {
+          "type": "string"
+        },
+        "db_instance_identifier": {
+          "type": "string"
+        },
+        "db_instance_resource_id": {
+          "type": "string"
+        },
+        "db_instance_status": {
+          "type": "string"
+        },
+        "db_instance_name": {
+          "type": "string"
+        },
+        "db_instance_username": {
+          "type": "string"
+        },
+        "db_instance_port": {
+          "type": "string"
+        },
+        "db_instance_ca_cert_identifier": {
+          "type": "string"
+        },
+        "db_instance_domain": {
+          "type": "string"
+        },
+        "db_instance_domain_auth_secret_arn": {
+          "type": "string"
+        },
+        "db_instance_domain_dns_ips": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "db_instance_domain_fqdn": {
+          "type": "string"
+        },
+        "db_instance_domain_iam_role_name": {
+          "type": "string"
+        },
+        "db_instance_domain_ou": {
+          "type": "string"
+        },
+        "db_instance_master_user_secret_arn": {
+          "type": "string"
+        },
+        "db_instance_cloudwatch_log_groups": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "db_instance_secretsmanager_secret_rotation_enabled": {
+          "type": "boolean"
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-s3-bucket.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-s3-bucket.json
@@ -1,0 +1,44 @@
+{
+    "source": "terraform-aws-modules/s3-bucket/aws",
+    "maximumVersion": "5.0.0",
+    "partialSchema": {
+      "outputs": {
+        "s3_bucket_id": {
+          "type": "string"
+        },
+        "s3_bucket_arn": {
+          "type": "string"
+        },
+        "s3_bucket_bucket_domain_name": {
+          "type": "string"
+        },
+        "s3_bucket_bucket_regional_domain_name": {
+          "type": "string"
+        },
+        "s3_bucket_hosted_zone_id": {
+          "type": "string"
+        },
+        "s3_bucket_lifecycle_configuration_rules": {
+          "$ref": "pulumi.json#/Any"
+        },
+        "s3_bucket_policy": {
+          "type": "string"
+        },
+        "s3_bucket_region": {
+          "type": "string"
+        },
+        "s3_bucket_website_endpoint": {
+          "type": "string"
+        },
+        "s3_bucket_website_domain": {
+          "type": "string"
+        },
+        "s3_directory_bucket_name": {
+          "type": "string"
+        },
+        "s3_directory_bucket_arn": {
+          "type": "string"
+        }
+      }
+    }
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
@@ -2,6 +2,415 @@
     "source": "terraform-aws-modules/vpc/aws",
     "maximumVersion": "6.0.0",
     "partialSchema": {
-        "nonNilOutputs": ["vpc_id"]
+      "outputs": {
+        "vpc_enable_dns_support": {
+          "type": "boolean"
+        },
+        "vpc_enable_dns_hostnames": {
+          "type": "boolean"
+        },
+        "vpc_secondary_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "vpc_owner_id": {
+          "type": "string"
+        },
+        "vpc_block_public_access_exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "egress_only_internet_gateway_id": {
+          "type": "string"
+        },
+        "nat_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nat_public_ips": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "natgw_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cgw_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cgw_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "this_customer_gateway": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "default_vpc_enable_dns_support": {
+          "type": "boolean"
+        },
+        "default_vpc_enable_dns_hostnames": {
+          "type": "boolean"
+        },
+        "private_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outpost_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outpost_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outpost_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outpost_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_subnet_group": {
+          "type": "string"
+        },
+        "database_subnet_group_name": {
+          "type": "string"
+        },
+        "redshift_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_subnet_group": {
+          "type": "string"
+        },
+        "elasticache_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_subnet_group": {
+          "type": "string"
+        },
+        "elasticache_subnet_group_name": {
+          "type": "string"
+        },
+        "intra_subnets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intra_subnet_arns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intra_subnets_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intra_subnets_ipv6_cidr_blocks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intra_route_table_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_nat_gateway_route_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_internet_gateway_route_id": {
+          "type": "string"
+        },
+        "public_internet_gateway_ipv6_route_id": {
+          "type": "string"
+        },
+        "database_internet_gateway_route_id": {
+          "type": "string"
+        },
+        "database_nat_gateway_route_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_ipv6_egress_route_id": {
+          "type": "string"
+        },
+        "private_ipv6_egress_route_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "private_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "database_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redshift_public_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "elasticache_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intra_route_table_association_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public_network_acl_id": {
+          "type": "string"
+        },
+        "public_network_acl_arn": {
+          "type": "string"
+        },
+        "private_network_acl_id": {
+          "type": "string"
+        },
+        "private_network_acl_arn": {
+          "type": "string"
+        },
+        "outpost_network_acl_id": {
+          "type": "string"
+        },
+        "outpost_network_acl_arn": {
+          "type": "string"
+        },
+        "intra_network_acl_id": {
+          "type": "string"
+        },
+        "intra_network_acl_arn": {
+          "type": "string"
+        },
+        "database_network_acl_id": {
+          "type": "string"
+        },
+        "database_network_acl_arn": {
+          "type": "string"
+        },
+        "redshift_network_acl_id": {
+          "type": "string"
+        },
+        "redshift_network_acl_arn": {
+          "type": "string"
+        },
+        "elasticache_network_acl_id": {
+          "type": "string"
+        },
+        "elasticache_network_acl_arn": {
+          "type": "string"
+        },
+        "azs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     }
-}
+  }

--- a/pkg/modprovider/module_schema_overrides/terraform-azurerm-virtualnetwork.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-azurerm-virtualnetwork.json
@@ -1,0 +1,69 @@
+{
+  "source": "Azure/avm-res-network-virtualnetwork/azurerm",
+  "maximumVersion": "1.0.0",
+  "partialSchema": {
+    "outputs": {
+      "peerings": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/[packageName]:index:PeeringResource"
+        }
+      },
+      "subnets": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/[packageName]:index:SubnetResource"
+        }
+      },
+      "resource": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      }
+    },
+    "supportingTypes": {
+      "[packageName]:index:SubnetResource": {
+        "type": "object",
+        "properties": {
+          "application_gateway_ip_configuration_resource_id": {
+            "type": "string"
+          }, 
+          "name": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
+          },
+          "resource_id": {
+            "type": "string"
+          }
+        }
+      },
+      "[packageName]:index:PeeringResource": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the peering resource"
+          },
+          "resource_id": {
+            "type": "string",
+            "description": "The resource ID of the peering resource"
+          },
+          "reverse_name": {
+            "type": "string",
+            "description": "The name of the reverse peering resource"
+          },
+          "reverse_resource_id": {
+            "type": "string",
+            "description": "The resource ID of the reverse peering resource"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-google-kubernetes-engine.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-google-kubernetes-engine.json
@@ -1,0 +1,68 @@
+{
+    "source": "terraform-google-modules/kubernetes-engine/google",
+    "maximumVersion": "37.0.0",
+    "partialSchema": {
+        "outputs": {
+            "dns_cache_enabled": {
+                "type": "boolean"
+            },
+            "horizontal_pod_autoscaling_enabled": {
+                "type": "boolean"
+            },
+            "http_load_balancing_enabled": {
+                "type": "boolean"
+            },
+            "identity_service_enabled": {
+                "type": "boolean"
+            },
+            "instance_group_urls": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "intranode_visibility_enabled": {
+                "type": "boolean"
+            },
+            "master_authorized_networks_config": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "pulumi.json#/Any"
+                }
+            },
+            "mesh_certificates_config": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "pulumi.json#/Any"
+                }
+            },
+            "network_policy_enabled": {
+                "type": "boolean"
+            },
+            "node_pools_names": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "node_pools_versions": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            },
+            "secret_manager_addon_enabled": {
+                "type": "boolean"
+            },
+            "vertical_pod_autoscaling_enabled": {
+                "type": "boolean"
+            },
+            "zones": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-google-network.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-google-network.json
@@ -1,0 +1,53 @@
+{
+  "source": "terraform-google-modules/network/google",
+  "maximumVersion": "11.0.0",
+  "partialSchema": {
+    "outputs": {
+      "network": {
+        "$ref": "pulumi.json#/Any"
+      },
+      "subnets": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "subnets_names": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnets_ips": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnets_regions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "route_names": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnets_private_access": {
+        "$ref": "pulumi.json#/Any"
+      },
+      "subnets_flow_logs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnets_secondary_ranges": {
+        "$ref": "pulumi.json#/Any"
+      }
+    }
+  }
+}

--- a/pkg/modprovider/module_schema_overrides/terraform-google-project-factory.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-google-project-factory.json
@@ -1,0 +1,74 @@
+{
+    "source": "terraform-google-modules/project-factory/google",
+    "maximumVersion": "19.0.0",
+    "partialSchema": {
+      "outputs": {
+        "project_name": {
+          "type": "string"
+        },
+        "project_id": {
+          "type": "string"
+        },
+        "project_number": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "group_email": {
+          "type": "string"
+        },
+        "service_account_id": {
+          "type": "string"
+        },
+        "service_account_display_name": {
+          "type": "string"
+        },
+        "service_account_email": {
+          "type": "string"
+        },
+        "service_account_name": {
+          "type": "string"
+        },
+        "service_account_unique_id": {
+          "type": "string"
+        },
+        "project_bucket_self_link": {
+          "type": "string"
+        },
+        "project_bucket_url": {
+          "type": "string"
+        },
+        "api_s_account": {
+          "type": "string"
+        },
+        "api_s_account_fmt": {
+          "type": "string"
+        },
+        "enabled_apis": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enabled_api_identities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "budget_name": {
+          "type": "string"
+        },
+        "tag_bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "pulumi.json#/Any"
+          }
+        },
+        "usage_report_export_bucket": {
+          "type": "string"
+        }
+      }
+    }
+}

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -472,10 +472,12 @@ func combineInferredModuleSchema(
 
 		if input.TypeSpec.Items != nil {
 			existingInput.TypeSpec.Items = input.TypeSpec.Items
+			existingInput.TypeSpec.AdditionalProperties = nil
 		}
 
 		if input.TypeSpec.AdditionalProperties != nil {
 			existingInput.TypeSpec.AdditionalProperties = input.TypeSpec.AdditionalProperties
+			existingInput.TypeSpec.Items = nil
 		}
 	}
 
@@ -501,9 +503,11 @@ func combineInferredModuleSchema(
 		}
 		if output.TypeSpec.Items != nil {
 			existingOutput.TypeSpec.Items = output.TypeSpec.Items
+			existingOutput.TypeSpec.AdditionalProperties = nil
 		}
 		if output.TypeSpec.AdditionalProperties != nil {
 			existingOutput.TypeSpec.AdditionalProperties = output.TypeSpec.AdditionalProperties
+			existingOutput.TypeSpec.Items = nil
 		}
 	}
 


### PR DESCRIPTION
This PR adds a number of module schema overrides for popular TF modules, used https://library.tf/modules to see which modules are the most popular by number of downloads, then using [infer-tfmodule-schema](https://github.com/pulumi/pulumi-tool-infer-tfmodule-schema) to infer the outputs, at least the non-string ones.

Fixes #214 (override added for that specific module) 

