### PR TITLE
chore: double test shards to check PRs faster

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -3,7 +3,7 @@ template: parameterized-go
 noSchema: true
 major-version: 0
 test-folder: tests
-shards: 4
+shards: 8
 aws: true
 modulePath: .
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
         tools: pulumictl, pulumicli, go, schema-tools
         cache-go: false
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-region: us-east-2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,9 +88,13 @@ jobs:
       fail-fast: false
       matrix:
         total-shards:
-          - 4
+          - 8
         current-shard:
           - 0
           - 1
           - 2
           - 3
+          - 4
+          - 5
+          - 6
+          - 7


### PR DESCRIPTION
Noticing that sometimes PRs take 50 minutes to verify, hoping this small tweak will help us cut this time, at the cost of using more runners.