### PR TITLE
chore: fix pulumi codegen pin

### DIFF
--- a/tests/testdata/aws-vpc/go/go.mod
+++ b/tests/testdata/aws-vpc/go/go.mod
@@ -1,10 +1,10 @@
 module aws-vpc
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0
-	github.com/pulumi/pulumi-terraform-module/sdk/go/v5 v5.18.1
+	github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5 v5.18.1
 )
 
-replace github.com/pulumi/pulumi-terraform-module/sdks => ./sdks/vpc
+replace github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5 => ./sdks/vpc

--- a/tests/testdata/aws-vpc/go/main.go
+++ b/tests/testdata/aws-vpc/go/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-terraform-module/sdks/vpc"
+	"github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/aws-vpc/go/sdks/vpc/go.mod
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/go.mod
@@ -1,7 +1,5 @@
-module github.com/pulumi/pulumi-terraform-module/sdks
+module github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5
 
-go 1.22
-
-toolchain go1.23.5
+go 1.20
 
 require github.com/pulumi/pulumi/sdk/v3 v3.147.0

--- a/tests/testdata/aws-vpc/go/sdks/vpc/go.sum
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/go.sum
@@ -1,1 +1,0 @@
-github.com/pulumi/pulumi/sdk/v3 v3.147.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=

--- a/tests/testdata/aws-vpc/go/sdks/vpc/vpc/init.go
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/vpc/init.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi-terraform-module/sdks/vpc/internal"
+	"github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/aws-vpc/go/sdks/vpc/vpc/internal/pulumiUtilities.go
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/vpc/internal/pulumiUtilities.go
@@ -77,7 +77,7 @@ func PkgVersion() (semver.Version, error) {
 	}
 	type sentinal struct{}
 	pkgPath := reflect.TypeOf(sentinal{}).PkgPath()
-	re := regexp.MustCompile("^github.com/pulumi/pulumi-terraform-module/sdks/vpc(/v\\d+)?")
+	re := regexp.MustCompile("^github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc(/v\\d+)?")
 	if match := re.FindStringSubmatch(pkgPath); match != nil {
 		vStr := match[1]
 		if len(vStr) == 0 { // If the version capture group was empty, default to v1.

--- a/tests/testdata/aws-vpc/go/sdks/vpc/vpc/module.go
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/vpc/module.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-terraform-module/sdks/vpc/internal"
+	"github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -65,9 +65,9 @@ type Module struct {
 	// The ID of the security group created by default on Default VPC creation
 	Default_vpc_default_security_group_id pulumi.StringPtrOutput `pulumi:"default_vpc_default_security_group_id"`
 	// Whether or not the Default VPC has DNS hostname support
-	Default_vpc_enable_dns_hostnames pulumi.StringPtrOutput `pulumi:"default_vpc_enable_dns_hostnames"`
+	Default_vpc_enable_dns_hostnames pulumi.BoolPtrOutput `pulumi:"default_vpc_enable_dns_hostnames"`
 	// Whether or not the Default VPC has DNS support
-	Default_vpc_enable_dns_support pulumi.StringPtrOutput `pulumi:"default_vpc_enable_dns_support"`
+	Default_vpc_enable_dns_support pulumi.BoolPtrOutput `pulumi:"default_vpc_enable_dns_support"`
 	// The ID of the Default VPC
 	Default_vpc_id pulumi.StringPtrOutput `pulumi:"default_vpc_id"`
 	// Tenancy of instances spin up within Default VPC
@@ -85,7 +85,7 @@ type Module struct {
 	// List of IDs of the elasticache route table association
 	Elasticache_route_table_association_ids pulumi.StringArrayOutput `pulumi:"elasticache_route_table_association_ids"`
 	// List of IDs of elasticache route tables
-	Elasticache_route_table_ids pulumi.StringPtrOutput `pulumi:"elasticache_route_table_ids"`
+	Elasticache_route_table_ids pulumi.StringArrayOutput `pulumi:"elasticache_route_table_ids"`
 	// List of ARNs of elasticache subnets
 	Elasticache_subnet_arns pulumi.StringArrayOutput `pulumi:"elasticache_subnet_arns"`
 	// ID of elasticache subnet group
@@ -127,7 +127,7 @@ type Module struct {
 	// List of allocation ID of Elastic IPs created for AWS NAT Gateway
 	Nat_ids pulumi.StringArrayOutput `pulumi:"nat_ids"`
 	// List of public Elastic IPs created for AWS NAT Gateway
-	Nat_public_ips pulumi.StringPtrOutput `pulumi:"nat_public_ips"`
+	Nat_public_ips pulumi.StringArrayOutput `pulumi:"nat_public_ips"`
 	// List of NAT Gateway IDs
 	Natgw_ids pulumi.StringArrayOutput `pulumi:"natgw_ids"`
 	// List of Network Interface IDs assigned to NAT Gateways
@@ -157,7 +157,7 @@ type Module struct {
 	// List of IDs of the private route table association
 	Private_route_table_association_ids pulumi.StringArrayOutput `pulumi:"private_route_table_association_ids"`
 	// List of IDs of private route tables
-	Private_route_table_ids pulumi.StringPtrOutput `pulumi:"private_route_table_ids"`
+	Private_route_table_ids pulumi.StringArrayOutput `pulumi:"private_route_table_ids"`
 	// List of ARNs of private subnets
 	Private_subnet_arns pulumi.StringArrayOutput `pulumi:"private_subnet_arns"`
 	// A list of all private subnets, containing the full objects.
@@ -179,7 +179,7 @@ type Module struct {
 	// List of IDs of the public route table association
 	Public_route_table_association_ids pulumi.StringArrayOutput `pulumi:"public_route_table_association_ids"`
 	// List of IDs of public route tables
-	Public_route_table_ids pulumi.StringPtrOutput `pulumi:"public_route_table_ids"`
+	Public_route_table_ids pulumi.StringArrayOutput `pulumi:"public_route_table_ids"`
 	// List of ARNs of public subnets
 	Public_subnet_arns pulumi.StringArrayOutput `pulumi:"public_subnet_arns"`
 	// A list of all public subnets, containing the full objects.
@@ -199,7 +199,7 @@ type Module struct {
 	// List of IDs of the redshift route table association
 	Redshift_route_table_association_ids pulumi.StringArrayOutput `pulumi:"redshift_route_table_association_ids"`
 	// List of IDs of redshift route tables
-	Redshift_route_table_ids pulumi.StringPtrOutput `pulumi:"redshift_route_table_ids"`
+	Redshift_route_table_ids pulumi.StringArrayOutput `pulumi:"redshift_route_table_ids"`
 	// List of ARNs of redshift subnets
 	Redshift_subnet_arns pulumi.StringArrayOutput `pulumi:"redshift_subnet_arns"`
 	// ID of redshift subnet group
@@ -213,19 +213,20 @@ type Module struct {
 	// List of IPv6 cidr_blocks of redshift subnets in an IPv6 enabled VPC
 	Redshift_subnets_ipv6_cidr_blocks pulumi.StringArrayOutput `pulumi:"redshift_subnets_ipv6_cidr_blocks"`
 	// Map of Customer Gateway attributes
-	This_customer_gateway pulumi.StringPtrOutput `pulumi:"this_customer_gateway"`
+	This_customer_gateway pulumi.MapOutput `pulumi:"this_customer_gateway"`
 	// The ARN of the VPN Gateway
 	Vgw_arn pulumi.StringPtrOutput `pulumi:"vgw_arn"`
 	// The ID of the VPN Gateway
 	Vgw_id pulumi.StringPtrOutput `pulumi:"vgw_id"`
 	// The ARN of the VPC
-	Vpc_arn pulumi.StringPtrOutput `pulumi:"vpc_arn"`
+	Vpc_arn                            pulumi.StringPtrOutput `pulumi:"vpc_arn"`
+	Vpc_block_public_access_exclusions pulumi.MapOutput       `pulumi:"vpc_block_public_access_exclusions"`
 	// The CIDR block of the VPC
 	Vpc_cidr_block pulumi.StringPtrOutput `pulumi:"vpc_cidr_block"`
 	// Whether or not the VPC has DNS hostname support
-	Vpc_enable_dns_hostnames pulumi.StringPtrOutput `pulumi:"vpc_enable_dns_hostnames"`
+	Vpc_enable_dns_hostnames pulumi.BoolPtrOutput `pulumi:"vpc_enable_dns_hostnames"`
 	// Whether or not the VPC has DNS support
-	Vpc_enable_dns_support pulumi.StringPtrOutput `pulumi:"vpc_enable_dns_support"`
+	Vpc_enable_dns_support pulumi.BoolPtrOutput `pulumi:"vpc_enable_dns_support"`
 	// The ARN of the IAM role used when pushing logs to Cloudwatch log group
 	Vpc_flow_log_cloudwatch_iam_role_arn pulumi.StringPtrOutput `pulumi:"vpc_flow_log_cloudwatch_iam_role_arn"`
 	// The ARN of the IAM role used when pushing logs cross account
@@ -1370,13 +1371,13 @@ func (o ModuleOutput) Default_vpc_default_security_group_id() pulumi.StringPtrOu
 }
 
 // Whether or not the Default VPC has DNS hostname support
-func (o ModuleOutput) Default_vpc_enable_dns_hostnames() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Default_vpc_enable_dns_hostnames }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Default_vpc_enable_dns_hostnames() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Module) pulumi.BoolPtrOutput { return v.Default_vpc_enable_dns_hostnames }).(pulumi.BoolPtrOutput)
 }
 
 // Whether or not the Default VPC has DNS support
-func (o ModuleOutput) Default_vpc_enable_dns_support() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Default_vpc_enable_dns_support }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Default_vpc_enable_dns_support() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Module) pulumi.BoolPtrOutput { return v.Default_vpc_enable_dns_support }).(pulumi.BoolPtrOutput)
 }
 
 // The ID of the Default VPC
@@ -1420,8 +1421,8 @@ func (o ModuleOutput) Elasticache_route_table_association_ids() pulumi.StringArr
 }
 
 // List of IDs of elasticache route tables
-func (o ModuleOutput) Elasticache_route_table_ids() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Elasticache_route_table_ids }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Elasticache_route_table_ids() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.StringArrayOutput { return v.Elasticache_route_table_ids }).(pulumi.StringArrayOutput)
 }
 
 // List of ARNs of elasticache subnets
@@ -1525,8 +1526,8 @@ func (o ModuleOutput) Nat_ids() pulumi.StringArrayOutput {
 }
 
 // List of public Elastic IPs created for AWS NAT Gateway
-func (o ModuleOutput) Nat_public_ips() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Nat_public_ips }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Nat_public_ips() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.StringArrayOutput { return v.Nat_public_ips }).(pulumi.StringArrayOutput)
 }
 
 // List of NAT Gateway IDs
@@ -1600,8 +1601,8 @@ func (o ModuleOutput) Private_route_table_association_ids() pulumi.StringArrayOu
 }
 
 // List of IDs of private route tables
-func (o ModuleOutput) Private_route_table_ids() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Private_route_table_ids }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Private_route_table_ids() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.StringArrayOutput { return v.Private_route_table_ids }).(pulumi.StringArrayOutput)
 }
 
 // List of ARNs of private subnets
@@ -1655,8 +1656,8 @@ func (o ModuleOutput) Public_route_table_association_ids() pulumi.StringArrayOut
 }
 
 // List of IDs of public route tables
-func (o ModuleOutput) Public_route_table_ids() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Public_route_table_ids }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Public_route_table_ids() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.StringArrayOutput { return v.Public_route_table_ids }).(pulumi.StringArrayOutput)
 }
 
 // List of ARNs of public subnets
@@ -1705,8 +1706,8 @@ func (o ModuleOutput) Redshift_route_table_association_ids() pulumi.StringArrayO
 }
 
 // List of IDs of redshift route tables
-func (o ModuleOutput) Redshift_route_table_ids() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Redshift_route_table_ids }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Redshift_route_table_ids() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.StringArrayOutput { return v.Redshift_route_table_ids }).(pulumi.StringArrayOutput)
 }
 
 // List of ARNs of redshift subnets
@@ -1740,8 +1741,8 @@ func (o ModuleOutput) Redshift_subnets_ipv6_cidr_blocks() pulumi.StringArrayOutp
 }
 
 // Map of Customer Gateway attributes
-func (o ModuleOutput) This_customer_gateway() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.This_customer_gateway }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) This_customer_gateway() pulumi.MapOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapOutput { return v.This_customer_gateway }).(pulumi.MapOutput)
 }
 
 // The ARN of the VPN Gateway
@@ -1759,19 +1760,23 @@ func (o ModuleOutput) Vpc_arn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_arn }).(pulumi.StringPtrOutput)
 }
 
+func (o ModuleOutput) Vpc_block_public_access_exclusions() pulumi.MapOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapOutput { return v.Vpc_block_public_access_exclusions }).(pulumi.MapOutput)
+}
+
 // The CIDR block of the VPC
 func (o ModuleOutput) Vpc_cidr_block() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_cidr_block }).(pulumi.StringPtrOutput)
 }
 
 // Whether or not the VPC has DNS hostname support
-func (o ModuleOutput) Vpc_enable_dns_hostnames() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_enable_dns_hostnames }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Vpc_enable_dns_hostnames() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Module) pulumi.BoolPtrOutput { return v.Vpc_enable_dns_hostnames }).(pulumi.BoolPtrOutput)
 }
 
 // Whether or not the VPC has DNS support
-func (o ModuleOutput) Vpc_enable_dns_support() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_enable_dns_support }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Vpc_enable_dns_support() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Module) pulumi.BoolPtrOutput { return v.Vpc_enable_dns_support }).(pulumi.BoolPtrOutput)
 }
 
 // The ARN of the IAM role used when pushing logs to Cloudwatch log group

--- a/tests/testdata/aws-vpc/go/sdks/vpc/vpc/provider.go
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/vpc/provider.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-terraform-module/sdks/vpc/internal"
+	"github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/aws-vpc/go/sdks/vpc/vpc/pulumiTypes.go
+++ b/tests/testdata/aws-vpc/go/sdks/vpc/vpc/pulumiTypes.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-terraform-module/sdks/vpc/internal"
+	"github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v5/vpc/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
+++ b/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
@@ -9,8 +9,11 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.vpc.ModuleArgs;
 import com.pulumi.vpc.Utilities;
+import java.lang.Boolean;
+import java.lang.Object;
 import java.lang.String;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -370,28 +373,28 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * Whether or not the Default VPC has DNS hostname support
      * 
      */
-    @Export(name="default_vpc_enable_dns_hostnames", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> default_vpc_enable_dns_hostnames;
+    @Export(name="default_vpc_enable_dns_hostnames", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> default_vpc_enable_dns_hostnames;
 
     /**
      * @return Whether or not the Default VPC has DNS hostname support
      * 
      */
-    public Output<Optional<String>> default_vpc_enable_dns_hostnames() {
+    public Output<Optional<Boolean>> default_vpc_enable_dns_hostnames() {
         return Codegen.optional(this.default_vpc_enable_dns_hostnames);
     }
     /**
      * Whether or not the Default VPC has DNS support
      * 
      */
-    @Export(name="default_vpc_enable_dns_support", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> default_vpc_enable_dns_support;
+    @Export(name="default_vpc_enable_dns_support", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> default_vpc_enable_dns_support;
 
     /**
      * @return Whether or not the Default VPC has DNS support
      * 
      */
-    public Output<Optional<String>> default_vpc_enable_dns_support() {
+    public Output<Optional<Boolean>> default_vpc_enable_dns_support() {
         return Codegen.optional(this.default_vpc_enable_dns_support);
     }
     /**
@@ -510,14 +513,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * List of IDs of elasticache route tables
      * 
      */
-    @Export(name="elasticache_route_table_ids", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> elasticache_route_table_ids;
+    @Export(name="elasticache_route_table_ids", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> elasticache_route_table_ids;
 
     /**
      * @return List of IDs of elasticache route tables
      * 
      */
-    public Output<Optional<String>> elasticache_route_table_ids() {
+    public Output<Optional<List<String>>> elasticache_route_table_ids() {
         return Codegen.optional(this.elasticache_route_table_ids);
     }
     /**
@@ -804,14 +807,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * List of public Elastic IPs created for AWS NAT Gateway
      * 
      */
-    @Export(name="nat_public_ips", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> nat_public_ips;
+    @Export(name="nat_public_ips", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> nat_public_ips;
 
     /**
      * @return List of public Elastic IPs created for AWS NAT Gateway
      * 
      */
-    public Output<Optional<String>> nat_public_ips() {
+    public Output<Optional<List<String>>> nat_public_ips() {
         return Codegen.optional(this.nat_public_ips);
     }
     /**
@@ -1014,14 +1017,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * List of IDs of private route tables
      * 
      */
-    @Export(name="private_route_table_ids", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> private_route_table_ids;
+    @Export(name="private_route_table_ids", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> private_route_table_ids;
 
     /**
      * @return List of IDs of private route tables
      * 
      */
-    public Output<Optional<String>> private_route_table_ids() {
+    public Output<Optional<List<String>>> private_route_table_ids() {
         return Codegen.optional(this.private_route_table_ids);
     }
     /**
@@ -1168,14 +1171,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * List of IDs of public route tables
      * 
      */
-    @Export(name="public_route_table_ids", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> public_route_table_ids;
+    @Export(name="public_route_table_ids", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> public_route_table_ids;
 
     /**
      * @return List of IDs of public route tables
      * 
      */
-    public Output<Optional<String>> public_route_table_ids() {
+    public Output<Optional<List<String>>> public_route_table_ids() {
         return Codegen.optional(this.public_route_table_ids);
     }
     /**
@@ -1308,14 +1311,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * List of IDs of redshift route tables
      * 
      */
-    @Export(name="redshift_route_table_ids", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> redshift_route_table_ids;
+    @Export(name="redshift_route_table_ids", refs={List.class,String.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<String>> redshift_route_table_ids;
 
     /**
      * @return List of IDs of redshift route tables
      * 
      */
-    public Output<Optional<String>> redshift_route_table_ids() {
+    public Output<Optional<List<String>>> redshift_route_table_ids() {
         return Codegen.optional(this.redshift_route_table_ids);
     }
     /**
@@ -1406,14 +1409,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * Map of Customer Gateway attributes
      * 
      */
-    @Export(name="this_customer_gateway", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> this_customer_gateway;
+    @Export(name="this_customer_gateway", refs={Map.class,String.class,Object.class}, tree="[0,1,2]")
+    private Output</* @Nullable */ Map<String,Object>> this_customer_gateway;
 
     /**
      * @return Map of Customer Gateway attributes
      * 
      */
-    public Output<Optional<String>> this_customer_gateway() {
+    public Output<Optional<Map<String,Object>>> this_customer_gateway() {
         return Codegen.optional(this.this_customer_gateway);
     }
     /**
@@ -1458,6 +1461,12 @@ public class Module extends com.pulumi.resources.ComponentResource {
     public Output<Optional<String>> vpc_arn() {
         return Codegen.optional(this.vpc_arn);
     }
+    @Export(name="vpc_block_public_access_exclusions", refs={Map.class,String.class,Object.class}, tree="[0,1,2]")
+    private Output</* @Nullable */ Map<String,Object>> vpc_block_public_access_exclusions;
+
+    public Output<Optional<Map<String,Object>>> vpc_block_public_access_exclusions() {
+        return Codegen.optional(this.vpc_block_public_access_exclusions);
+    }
     /**
      * The CIDR block of the VPC
      * 
@@ -1476,28 +1485,28 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * Whether or not the VPC has DNS hostname support
      * 
      */
-    @Export(name="vpc_enable_dns_hostnames", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> vpc_enable_dns_hostnames;
+    @Export(name="vpc_enable_dns_hostnames", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> vpc_enable_dns_hostnames;
 
     /**
      * @return Whether or not the VPC has DNS hostname support
      * 
      */
-    public Output<Optional<String>> vpc_enable_dns_hostnames() {
+    public Output<Optional<Boolean>> vpc_enable_dns_hostnames() {
         return Codegen.optional(this.vpc_enable_dns_hostnames);
     }
     /**
      * Whether or not the VPC has DNS support
      * 
      */
-    @Export(name="vpc_enable_dns_support", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> vpc_enable_dns_support;
+    @Export(name="vpc_enable_dns_support", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> vpc_enable_dns_support;
 
     /**
      * @return Whether or not the VPC has DNS support
      * 
      */
-    public Output<Optional<String>> vpc_enable_dns_support() {
+    public Output<Optional<Boolean>> vpc_enable_dns_support() {
         return Codegen.optional(this.vpc_enable_dns_support);
     }
     /**
@@ -1575,14 +1584,14 @@ public class Module extends com.pulumi.resources.ComponentResource {
      * 
      */
     @Export(name="vpc_id", refs={String.class}, tree="[0]")
-    private Output<String> vpc_id;
+    private Output</* @Nullable */ String> vpc_id;
 
     /**
      * @return The ID of the VPC
      * 
      */
-    public Output<String> vpc_id() {
-        return this.vpc_id;
+    public Output<Optional<String>> vpc_id() {
+        return Codegen.optional(this.vpc_id);
     }
     /**
      * Tenancy of instances spin up within VPC

--- a/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/ProviderArgs.java
+++ b/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/ProviderArgs.java
@@ -3,15 +3,46 @@
 
 package com.pulumi.vpc;
 
-
+import com.pulumi.core.Output;
+import com.pulumi.core.annotations.Import;
+import java.lang.Object;
+import java.lang.String;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 
 public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final ProviderArgs Empty = new ProviderArgs();
 
+    /**
+     * provider configuration for aws
+     * 
+     */
+    @Import(name="aws", json=true)
+    private @Nullable Output<Map<String,Object>> aws;
+
+    /**
+     * @return provider configuration for aws
+     * 
+     */
+    public Optional<Output<Map<String,Object>>> aws() {
+        return Optional.ofNullable(this.aws);
+    }
+
+    private ProviderArgs() {}
+
+    private ProviderArgs(ProviderArgs $) {
+        this.aws = $.aws;
+    }
+
     public static Builder builder() {
         return new Builder();
+    }
+    public static Builder builder(ProviderArgs defaults) {
+        return new Builder(defaults);
     }
 
     public static final class Builder {
@@ -20,6 +51,32 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         public Builder() {
             $ = new ProviderArgs();
         }
+
+        public Builder(ProviderArgs defaults) {
+            $ = new ProviderArgs(Objects.requireNonNull(defaults));
+        }
+
+        /**
+         * @param aws provider configuration for aws
+         * 
+         * @return builder
+         * 
+         */
+        public Builder aws(@Nullable Output<Map<String,Object>> aws) {
+            $.aws = aws;
+            return this;
+        }
+
+        /**
+         * @param aws provider configuration for aws
+         * 
+         * @return builder
+         * 
+         */
+        public Builder aws(Map<String,Object> aws) {
+            return aws(Output.of(aws));
+        }
+
         public ProviderArgs build() {
             return $;
         }

--- a/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Utilities.java
+++ b/tests/testdata/aws-vpc/java/sdks/vpc/src/main/java/com/pulumi/vpc/Utilities.java
@@ -114,7 +114,7 @@ public class Utilities {
 			// Base provider name
 			"terraform-module",
 			// Base provider version
-			"0.0.1",
+			"0.0.0-alpha.0+dev",
 			// Base provider download URL
 			"",
 			// Package name

--- a/tests/testdata/aws-vpc/node/package.json
+++ b/tests/testdata/aws-vpc/node/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "aws-vpc",
 	"devDependencies": {
-		"@types/node": "^14"
+		"@types/node": "^18"
 	},
 	"dependencies": {
 		"@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/aws-vpc/node/sdks/vpc/module.ts
+++ b/tests/testdata/aws-vpc/node/sdks/vpc/module.ts
@@ -124,11 +124,11 @@ export class Module extends pulumi.ComponentResource {
     /**
      * Whether or not the Default VPC has DNS hostname support
      */
-    public readonly default_vpc_enable_dns_hostnames!: pulumi.Output<string | undefined>;
+    public readonly default_vpc_enable_dns_hostnames!: pulumi.Output<boolean | undefined>;
     /**
      * Whether or not the Default VPC has DNS support
      */
-    public readonly default_vpc_enable_dns_support!: pulumi.Output<string | undefined>;
+    public readonly default_vpc_enable_dns_support!: pulumi.Output<boolean | undefined>;
     /**
      * The ID of the Default VPC
      */
@@ -164,7 +164,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * List of IDs of elasticache route tables
      */
-    public /*out*/ readonly elasticache_route_table_ids!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly elasticache_route_table_ids!: pulumi.Output<string[] | undefined>;
     /**
      * List of ARNs of elasticache subnets
      */
@@ -248,7 +248,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * List of public Elastic IPs created for AWS NAT Gateway
      */
-    public /*out*/ readonly nat_public_ips!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly nat_public_ips!: pulumi.Output<string[] | undefined>;
     /**
      * List of NAT Gateway IDs
      */
@@ -308,7 +308,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * List of IDs of private route tables
      */
-    public /*out*/ readonly private_route_table_ids!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly private_route_table_ids!: pulumi.Output<string[] | undefined>;
     /**
      * List of ARNs of private subnets
      */
@@ -352,7 +352,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * List of IDs of public route tables
      */
-    public /*out*/ readonly public_route_table_ids!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly public_route_table_ids!: pulumi.Output<string[] | undefined>;
     /**
      * List of ARNs of public subnets
      */
@@ -392,7 +392,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * List of IDs of redshift route tables
      */
-    public /*out*/ readonly redshift_route_table_ids!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly redshift_route_table_ids!: pulumi.Output<string[] | undefined>;
     /**
      * List of ARNs of redshift subnets
      */
@@ -420,7 +420,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * Map of Customer Gateway attributes
      */
-    public /*out*/ readonly this_customer_gateway!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly this_customer_gateway!: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The ARN of the VPN Gateway
      */
@@ -433,6 +433,7 @@ export class Module extends pulumi.ComponentResource {
      * The ARN of the VPC
      */
     public /*out*/ readonly vpc_arn!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_block_public_access_exclusions!: pulumi.Output<{[key: string]: any} | undefined>;
     /**
      * The CIDR block of the VPC
      */
@@ -440,11 +441,11 @@ export class Module extends pulumi.ComponentResource {
     /**
      * Whether or not the VPC has DNS hostname support
      */
-    public /*out*/ readonly vpc_enable_dns_hostnames!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_enable_dns_hostnames!: pulumi.Output<boolean | undefined>;
     /**
      * Whether or not the VPC has DNS support
      */
-    public /*out*/ readonly vpc_enable_dns_support!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_enable_dns_support!: pulumi.Output<boolean | undefined>;
     /**
      * The ARN of the IAM role used when pushing logs to Cloudwatch log group
      */
@@ -468,7 +469,7 @@ export class Module extends pulumi.ComponentResource {
     /**
      * The ID of the VPC
      */
-    public /*out*/ readonly vpc_id!: pulumi.Output<string>;
+    public /*out*/ readonly vpc_id!: pulumi.Output<string | undefined>;
     /**
      * Tenancy of instances spin up within VPC
      */
@@ -827,6 +828,7 @@ export class Module extends pulumi.ComponentResource {
             resourceInputs["vgw_arn"] = undefined /*out*/;
             resourceInputs["vgw_id"] = undefined /*out*/;
             resourceInputs["vpc_arn"] = undefined /*out*/;
+            resourceInputs["vpc_block_public_access_exclusions"] = undefined /*out*/;
             resourceInputs["vpc_cidr_block"] = undefined /*out*/;
             resourceInputs["vpc_enable_dns_hostnames"] = undefined /*out*/;
             resourceInputs["vpc_enable_dns_support"] = undefined /*out*/;
@@ -946,6 +948,7 @@ export class Module extends pulumi.ComponentResource {
             resourceInputs["vgw_arn"] = undefined /*out*/;
             resourceInputs["vgw_id"] = undefined /*out*/;
             resourceInputs["vpc_arn"] = undefined /*out*/;
+            resourceInputs["vpc_block_public_access_exclusions"] = undefined /*out*/;
             resourceInputs["vpc_cidr_block"] = undefined /*out*/;
             resourceInputs["vpc_enable_dns_hostnames"] = undefined /*out*/;
             resourceInputs["vpc_enable_dns_support"] = undefined /*out*/;

--- a/tests/testdata/aws-vpc/node/sdks/vpc/package.json
+++ b/tests/testdata/aws-vpc/node/sdks/vpc/package.json
@@ -11,13 +11,13 @@
         "async-mutex": "^0.5.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
+        "@types/node": "^18",
         "typescript": "^4.3.5"
     },
     "pulumi": {
         "resource": true,
         "name": "terraform-module",
-        "version": "0.0.1",
+        "version": "0.0.0-alpha.0+dev",
         "parameterization": {
             "name": "vpc",
             "version": "5.18.1",

--- a/tests/testdata/aws-vpc/node/sdks/vpc/provider.ts
+++ b/tests/testdata/aws-vpc/node/sdks/vpc/provider.ts
@@ -31,6 +31,7 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
+            resourceInputs["aws"] = pulumi.output(args ? args.aws : undefined).apply(JSON.stringify);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts, false /*dependency*/, utilities.getPackage());
@@ -41,4 +42,8 @@ export class Provider extends pulumi.ProviderResource {
  * The set of arguments for constructing a Provider resource.
  */
 export interface ProviderArgs {
+    /**
+     * provider configuration for aws
+     */
+    aws?: pulumi.Input<{[key: string]: any}>;
 }

--- a/tests/testdata/aws-vpc/node/sdks/vpc/utilities.ts
+++ b/tests/testdata/aws-vpc/node/sdks/vpc/utilities.ts
@@ -114,7 +114,7 @@ export async function getPackage() : Promise<string | undefined> {
 
 			const req = new resproto.RegisterPackageRequest();
 			req.setName("terraform-module");
-			req.setVersion("0.0.1");
+			req.setVersion("0.0.0-alpha.0+dev");
 			req.setDownloadUrl("");
 			req.setParameterization(params);
 			const resp : any = await new Promise((resolve, reject) => {


### PR DESCRIPTION
Investigating why https://github.com/pulumi/pulumi-terraform-module/pull/319 PR is failing we probably are not correctly pinning Pulumi CLI in the TestGenerateTerraformAwsModulesSDKs test. Somehow the Pulumi CLI version from ESC toolscache path is starting to interfere. This PR is an attempt to get this more robust so that `.pulumi/bin/pulumi` pinned version is used exactly.

The code churn is from upgrading the test data to newer Pulumi CLI versions.