### PR TITLE
Refactor resource plans

### DIFF
--- a/pkg/modprovider/child.go
+++ b/pkg/modprovider/child.go
@@ -59,16 +59,17 @@ func newChildResource(
 	ctx *pulumi.Context,
 	modUrn resource.URN,
 	pkgName packageName,
-	sop ResourceStateOrPlan,
+	address ResourceAddress,
+	tfType TFResourceType,
+	values resource.PropertyMap,
 	packageRef string,
 	opts ...pulumi.ResourceOption,
 ) (*childResource, error) {
 	contract.Assertf(ctx != nil, "ctx must not be nil")
-	contract.Assertf(sop != nil, "sop must not be nil")
 	var resource childResource
-	inputs := childResourceInputs(modUrn, sop.Address(), sop.Values())
-	t := childResourceTypeToken(pkgName, sop.Type())
-	name := childResourceName(sop)
+	inputs := childResourceInputs(modUrn, address, values)
+	t := childResourceTypeToken(pkgName, tfType)
+	name := childResourceName(address)
 	inputsMap := pulumix.MustUnmarshalPropertyMap(ctx, inputs)
 	err := ctx.RegisterPackageResource(string(t), name, inputsMap, &resource, packageRef, opts...)
 	if err != nil {
@@ -95,16 +96,16 @@ func childResourceTypeToken(pkgName packageName, tfType TFResourceType) tokens.T
 //
 // Pulumi resources must be unique by URN, so the name has to be sufficiently unique that there are
 // no two resources with the same parent, type and name.
-func childResourceName(resource Resource) string {
-	return string(resource.Address())
+func childResourceName(resource ResourceAddress) string {
+	return string(resource)
 }
 
 // The ID to return for a child resource during Create.
-func childResourceID(resource Resource) string {
+func childResourceID(resource ResourceState) string {
 	// TODO this could try harder to expose e.g. bucket ID from the resource properties.
 	// For now just copy the name.
 
-	return childResourceName(resource)
+	return childResourceName(resource.Address())
 }
 
 // Model outputs as empty in Pulumi since they are not used at present.

--- a/pkg/modprovider/planstore.go
+++ b/pkg/modprovider/planstore.go
@@ -161,13 +161,11 @@ func (s *planStore) FindResourceState(
 	addr ResourceAddress,
 ) (ResourceState, error) {
 	modState := s.getOrCreateStateEntry(modUrn).Await()
-	sop, ok := modState.FindResourceStateOrPlan(addr)
+	rstate, ok := modState.FindResourceState(addr)
 	if !ok {
 		return nil, fmt.Errorf("FindResourceState: %w", unknownAddressError{addr})
 	}
-	st, ok := sop.(ResourceState)
-	contract.Assertf(ok, "FindResourceState: ResourceState cast must not fail")
-	return st, nil
+	return rstate, nil
 }
 
 func (s *planStore) FindResourcePlan(
@@ -175,13 +173,12 @@ func (s *planStore) FindResourcePlan(
 	addr ResourceAddress,
 ) (ResourcePlan, error) {
 	modPlan := s.getOrCreatePlanEntry(modUrn).Await()
-	sop, ok := modPlan.FindResourceStateOrPlan(addr)
+	rplan, ok := modPlan.FindResourcePlan(addr)
 	if !ok {
 		return nil, fmt.Errorf("FindResourcePlan: %w", unknownAddressError{addr})
 	}
-	st, ok := sop.(ResourcePlan)
 	contract.Assertf(ok, "FindResourcePlan: ResourcePlan cast must not fail")
-	return st, nil
+	return rplan, nil
 }
 
 func (s *planStore) MustFindResourcePlan(

--- a/pkg/modprovider/resources.go
+++ b/pkg/modprovider/resources.go
@@ -1,57 +1,15 @@
 package modprovider
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-
 	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
 type (
-	ResourceAddress     = tfsandbox.ResourceAddress
-	TFResourceType      = tfsandbox.TFResourceType
-	ChangeKind          = tfsandbox.ChangeKind
-	ResourceStateOrPlan = tfsandbox.ResourceStateOrPlan
+	ResourceAddress = tfsandbox.ResourceAddress
+	TFResourceType  = tfsandbox.TFResourceType
+	ChangeKind      = tfsandbox.ChangeKind
+	ResourcePlan    = *tfsandbox.ResourcePlan
+	ResourceState   = *tfsandbox.ResourceState
+	Plan            = *tfsandbox.Plan
+	State           = *tfsandbox.State
 )
-
-type Resource interface {
-	Address() ResourceAddress
-
-	// The resource type, example: "aws_instance" for aws_instance.foo.
-	Type() TFResourceType
-
-	// The resource name, example: "foo" for aws_instance.foo.
-	Name() string
-}
-
-var _ Resource = (*tfsandbox.Resource)(nil)
-
-type ResourcePlan interface {
-	Resource
-	ChangeKind() ChangeKind
-	PlannedValues() resource.PropertyMap
-}
-
-var _ ResourcePlan = (*tfsandbox.ResourcePlan)(nil)
-
-type ResourceState interface {
-	Resource
-	AttributeValues() resource.PropertyMap
-}
-
-type Resources interface {
-	FindResourceStateOrPlan(ResourceAddress) (tfsandbox.ResourceStateOrPlan, bool)
-}
-
-var _ ResourceState = (*tfsandbox.ResourceState)(nil)
-
-type Plan interface {
-	Resources
-}
-
-var _ Plan = (*tfsandbox.Plan)(nil)
-
-type State interface {
-	Resources // returns ResourceStateOrPlan=ResourceState
-}
-
-var _ State = (*tfsandbox.State)(nil)

--- a/pkg/tfsandbox/apply.go
+++ b/pkg/tfsandbox/apply.go
@@ -15,7 +15,7 @@ import (
 // the state and the apply error.
 func (t *Tofu) Apply(ctx context.Context, logger Logger) (*State, error) {
 	state, applyErr := t.apply(ctx, logger)
-	s, err := newState(state)
+	s, err := NewState(state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfsandbox/plan.go
+++ b/pkg/tfsandbox/plan.go
@@ -30,7 +30,7 @@ func (t *Tofu) Plan(ctx context.Context, logger Logger) (*Plan, error) {
 	if err != nil {
 		return nil, err
 	}
-	p, err := newPlan(plan)
+	p, err := NewPlan(plan)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (t *Tofu) PlanRefreshOnly(ctx context.Context, logger Logger) (*Plan, error
 		return nil, err
 	}
 
-	p, err := newPlan(plan)
+	p, err := NewPlan(plan)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfsandbox/plan_test.go
+++ b/pkg/tfsandbox/plan_test.go
@@ -20,11 +20,12 @@ func TestProcessPlan(t *testing.T) {
 		var tfState *tfjson.Plan
 		err = json.Unmarshal(planData, &tfState)
 		assert.NoError(t, err)
-		plan, err := newPlan(tfState)
+		plan, err := NewPlan(tfState)
 		assert.NoError(t, err)
 		resourceProps := map[string]resource.PropertyMap{}
-		plan.Resources.VisitResources(func(rp *ResourcePlan) {
-			resourceProps[rp.sr.Address] = rp.props
+		plan.VisitResourcePlans(func(rp *ResourcePlan) {
+			props, _ := rp.PlannedValues()
+			resourceProps[string(rp.Address())] = props
 		})
 		autogold.ExpectFile(t, resourceProps)
 	})
@@ -36,12 +37,13 @@ func TestProcessPlan(t *testing.T) {
 		err = json.Unmarshal(planData, &tfState)
 		assert.NoError(t, err)
 
-		plan, err := newPlan(tfState)
+		plan, err := NewPlan(tfState)
 		assert.NoError(t, err)
-		plan.VisitResources(func(rp *ResourcePlan) {
+		plan.VisitResourcePlans(func(rp *ResourcePlan) {
 			// This is the only resource that has a diff in this plan file
 			if rp.Type() == "aws_s3_bucket_server_side_encryption_configuration" {
-				autogold.ExpectFile(t, rp.props)
+				props, _ := rp.PlannedValues()
+				autogold.ExpectFile(t, props)
 			}
 		})
 	})
@@ -53,11 +55,12 @@ func TestProcessPlan(t *testing.T) {
 		err = json.Unmarshal(planData, &tfState)
 		assert.NoError(t, err)
 
-		plan, err := newPlan(tfState)
+		plan, err := NewPlan(tfState)
 		assert.NoError(t, err)
 		resourceProps := map[string]resource.PropertyMap{}
-		plan.Resources.VisitResources(func(rp *ResourcePlan) {
-			resourceProps[rp.sr.Address] = rp.props
+		plan.VisitResourcePlans(func(rp *ResourcePlan) {
+			props, _ := rp.PlannedValues()
+			resourceProps[string(rp.Address())] = props
 		})
 		autogold.ExpectFile(t, resourceProps)
 	})

--- a/pkg/tfsandbox/refresh.go
+++ b/pkg/tfsandbox/refresh.go
@@ -12,7 +12,7 @@ func (t *Tofu) Refresh(ctx context.Context, log Logger) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := newState(st)
+	s, err := NewState(st)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfsandbox/resources.go
+++ b/pkg/tfsandbox/resources.go
@@ -23,6 +23,9 @@ type stateResources map[ResourceAddress]tfjson.StateResource
 // newStateResources creates a new stateResources object from a tfjson.StateModule
 func newStateResources(module *tfjson.StateModule) (stateResources, error) {
 	resources := make(stateResources)
+	if module == nil {
+		return resources, nil
+	}
 	if err := resources.extractResourcesFromStateModule(module); err != nil {
 		return nil, err
 	}

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -86,7 +86,7 @@ func TestState(t *testing.T) {
 	require.NoError(t, err)
 
 	resourceCount := 0
-	state.Resources.VisitResources(func(_ *ResourceState) {
+	state.VisitResourceStates(func(_ *ResourceState) {
 		resourceCount++
 	})
 
@@ -104,10 +104,10 @@ func TestState(t *testing.T) {
 	require.NoError(t, err, "error replanning")
 
 	hasUpdates := false
-	plan.VisitResources(func(rp *ResourcePlan) {
+	plan.VisitResourcePlans(func(rp *ResourcePlan) {
 		if rp.ChangeKind() == Update {
 			hasUpdates = true
-			t.Logf("Planning to update %s", rp.GetResource().Address())
+			t.Logf("Planning to update %s", rp.Address())
 		}
 	})
 

--- a/pkg/tfsandbox/testdata/plans/delete_plan.json
+++ b/pkg/tfsandbox/testdata/plans/delete_plan.json
@@ -1,0 +1,3437 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.1",
+  "planned_values": {
+    "outputs": {
+      "internal_output_is_secret_s3_bucket_arn": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_bucket_domain_name": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_bucket_regional_domain_name": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_hosted_zone_id": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_id": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_lifecycle_configuration_rules": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_policy": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_region": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_website_domain": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "internal_output_is_secret_s3_bucket_website_endpoint": {
+        "sensitive": false,
+        "value": false,
+        "type": "bool"
+      },
+      "s3_bucket_arn": {
+        "sensitive": false,
+        "value": "arn:aws:s3:::852809-test-bucket",
+        "type": "string"
+      },
+      "s3_bucket_bucket_domain_name": {
+        "sensitive": false,
+        "value": "852809-test-bucket.s3.amazonaws.com",
+        "type": "string"
+      },
+      "s3_bucket_bucket_regional_domain_name": {
+        "sensitive": false,
+        "value": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+        "type": "string"
+      },
+      "s3_bucket_hosted_zone_id": {
+        "sensitive": false,
+        "value": "Z3BJ6K6RIION7M",
+        "type": "string"
+      },
+      "s3_bucket_id": {
+        "sensitive": false,
+        "value": "852809-test-bucket",
+        "type": "string"
+      },
+      "s3_bucket_lifecycle_configuration_rules": {
+        "sensitive": false,
+        "value": "",
+        "type": "string"
+      },
+      "s3_bucket_policy": {
+        "sensitive": false,
+        "value": "",
+        "type": "string"
+      },
+      "s3_bucket_region": {
+        "sensitive": false,
+        "value": "us-west-2",
+        "type": "string"
+      },
+      "s3_bucket_website_domain": {
+        "sensitive": false,
+        "value": "",
+        "type": "string"
+      },
+      "s3_bucket_website_endpoint": {
+        "sensitive": false,
+        "value": "",
+        "type": "string"
+      }
+    },
+    "root_module": {
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.test-bucket.aws_s3_bucket.this[0]",
+              "mode": "managed",
+              "type": "aws_s3_bucket",
+              "name": "this",
+              "index": 0,
+              "provider_name": "registry.opentofu.org/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "acceleration_status": "",
+                "acl": null,
+                "arn": "arn:aws:s3:::852809-test-bucket",
+                "bucket": "852809-test-bucket",
+                "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+                "bucket_prefix": "",
+                "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+                "cors_rule": [],
+                "force_destroy": false,
+                "grant": [
+                  {
+                    "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                    "permissions": [
+                      "FULL_CONTROL"
+                    ],
+                    "type": "CanonicalUser",
+                    "uri": ""
+                  }
+                ],
+                "hosted_zone_id": "Z3BJ6K6RIION7M",
+                "id": "852809-test-bucket",
+                "lifecycle_rule": [],
+                "logging": [],
+                "object_lock_configuration": [],
+                "object_lock_enabled": false,
+                "policy": "",
+                "region": "us-west-2",
+                "replication_configuration": [],
+                "request_payer": "BucketOwner",
+                "server_side_encryption_configuration": [
+                  {
+                    "rule": [
+                      {
+                        "apply_server_side_encryption_by_default": [
+                          {
+                            "kms_master_key_id": "",
+                            "sse_algorithm": "AES256"
+                          }
+                        ],
+                        "bucket_key_enabled": false
+                      }
+                    ]
+                  }
+                ],
+                "tags": {},
+                "tags_all": {},
+                "timeouts": null,
+                "versioning": [
+                  {
+                    "enabled": false,
+                    "mfa_delete": false
+                  }
+                ],
+                "website": [],
+                "website_domain": null,
+                "website_endpoint": null
+              },
+              "sensitive_values": {
+                "cors_rule": [],
+                "grant": [
+                  {
+                    "permissions": [
+                      false
+                    ]
+                  }
+                ],
+                "lifecycle_rule": [],
+                "logging": [],
+                "object_lock_configuration": [],
+                "replication_configuration": [],
+                "server_side_encryption_configuration": [
+                  {
+                    "rule": [
+                      {
+                        "apply_server_side_encryption_by_default": [
+                          {}
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "tags": {},
+                "tags_all": {},
+                "versioning": [
+                  {}
+                ],
+                "website": []
+              }
+            },
+            {
+              "address": "module.test-bucket.aws_s3_bucket_public_access_block.this[0]",
+              "mode": "managed",
+              "type": "aws_s3_bucket_public_access_block",
+              "name": "this",
+              "index": 0,
+              "provider_name": "registry.opentofu.org/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "block_public_acls": true,
+                "block_public_policy": true,
+                "bucket": "852809-test-bucket",
+                "id": "852809-test-bucket",
+                "ignore_public_acls": true,
+                "restrict_public_buckets": true
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.test-bucket"
+        }
+      ]
+    }
+  },
+  "resource_drift": [
+    {
+      "address": "module.test-bucket.aws_s3_bucket.this[0]",
+      "module_address": "module.test-bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "this",
+      "index": 0,
+      "provider_name": "registry.opentofu.org/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::852809-test-bucket",
+          "bucket": "852809-test-bucket",
+          "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "852809-test-bucket",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": null,
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::852809-test-bucket",
+          "bucket": "852809-test-bucket",
+          "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "852809-test-bucket",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        },
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "module.test-bucket.aws_s3_bucket_server_side_encryption_configuration.this[0]",
+      "module_address": "module.test-bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "this",
+      "index": 0,
+      "provider_name": "registry.opentofu.org/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "bucket": "852809-test-bucket",
+          "expected_bucket_owner": "",
+          "id": "852809-test-bucket",
+          "rule": [
+            {
+              "apply_server_side_encryption_by_default": [
+                {
+                  "kms_master_key_id": "",
+                  "sse_algorithm": "AES256"
+                }
+              ],
+              "bucket_key_enabled": null
+            }
+          ]
+        },
+        "after": {
+          "bucket": "852809-test-bucket",
+          "expected_bucket_owner": "",
+          "id": "852809-test-bucket",
+          "rule": [
+            {
+              "apply_server_side_encryption_by_default": [
+                {
+                  "kms_master_key_id": "",
+                  "sse_algorithm": "AES256"
+                }
+              ],
+              "bucket_key_enabled": false
+            }
+          ]
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "rule": true
+        },
+        "after_sensitive": {
+          "rule": true
+        }
+      }
+    }
+  ],
+  "resource_changes": [
+    {
+      "address": "module.test-bucket.aws_s3_bucket.this[0]",
+      "module_address": "module.test-bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "this",
+      "index": 0,
+      "provider_name": "registry.opentofu.org/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::852809-test-bucket",
+          "bucket": "852809-test-bucket",
+          "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "852809-test-bucket",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::852809-test-bucket",
+          "bucket": "852809-test-bucket",
+          "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "852809-test-bucket",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        },
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "module.test-bucket.aws_s3_bucket_public_access_block.this[0]",
+      "module_address": "module.test-bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "this",
+      "index": 0,
+      "provider_name": "registry.opentofu.org/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "block_public_acls": true,
+          "block_public_policy": true,
+          "bucket": "852809-test-bucket",
+          "id": "852809-test-bucket",
+          "ignore_public_acls": true,
+          "restrict_public_buckets": true
+        },
+        "after": {
+          "block_public_acls": true,
+          "block_public_policy": true,
+          "bucket": "852809-test-bucket",
+          "id": "852809-test-bucket",
+          "ignore_public_acls": true,
+          "restrict_public_buckets": true
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.test-bucket.aws_s3_bucket_server_side_encryption_configuration.this[0]",
+      "module_address": "module.test-bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "this",
+      "index": 0,
+      "provider_name": "registry.opentofu.org/hashicorp/aws",
+      "change": {
+        "actions": [
+          "delete"
+        ],
+        "before": {
+          "bucket": "852809-test-bucket",
+          "expected_bucket_owner": "",
+          "id": "852809-test-bucket",
+          "rule": [
+            {
+              "apply_server_side_encryption_by_default": [
+                {
+                  "kms_master_key_id": "",
+                  "sse_algorithm": "AES256"
+                }
+              ],
+              "bucket_key_enabled": false
+            }
+          ]
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "rule": true
+        },
+        "after_sensitive": false
+      }
+    }
+  ],
+  "output_changes": {
+    "internal_output_is_secret_s3_bucket_arn": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_bucket_domain_name": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_bucket_regional_domain_name": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_hosted_zone_id": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_id": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_lifecycle_configuration_rules": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_policy": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_region": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_website_domain": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "internal_output_is_secret_s3_bucket_website_endpoint": {
+      "actions": [
+        "no-op"
+      ],
+      "before": false,
+      "after": false,
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_arn": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "arn:aws:s3:::852809-test-bucket",
+      "after": "arn:aws:s3:::852809-test-bucket",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_bucket_domain_name": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "852809-test-bucket.s3.amazonaws.com",
+      "after": "852809-test-bucket.s3.amazonaws.com",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_bucket_regional_domain_name": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+      "after": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_hosted_zone_id": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "Z3BJ6K6RIION7M",
+      "after": "Z3BJ6K6RIION7M",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_id": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "852809-test-bucket",
+      "after": "852809-test-bucket",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_lifecycle_configuration_rules": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "",
+      "after": "",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_policy": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "",
+      "after": "",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_region": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "us-west-2",
+      "after": "us-west-2",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_website_domain": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "",
+      "after": "",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "s3_bucket_website_endpoint": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "",
+      "after": "",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  },
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.9.1",
+    "values": {
+      "outputs": {
+        "internal_output_is_secret_s3_bucket_arn": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_bucket_domain_name": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_bucket_regional_domain_name": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_hosted_zone_id": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_id": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_lifecycle_configuration_rules": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_policy": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_region": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_website_domain": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "internal_output_is_secret_s3_bucket_website_endpoint": {
+          "sensitive": false,
+          "value": false,
+          "type": "bool"
+        },
+        "s3_bucket_arn": {
+          "sensitive": false,
+          "value": "arn:aws:s3:::852809-test-bucket",
+          "type": "string"
+        },
+        "s3_bucket_bucket_domain_name": {
+          "sensitive": false,
+          "value": "852809-test-bucket.s3.amazonaws.com",
+          "type": "string"
+        },
+        "s3_bucket_bucket_regional_domain_name": {
+          "sensitive": false,
+          "value": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+          "type": "string"
+        },
+        "s3_bucket_hosted_zone_id": {
+          "sensitive": false,
+          "value": "Z3BJ6K6RIION7M",
+          "type": "string"
+        },
+        "s3_bucket_id": {
+          "sensitive": false,
+          "value": "852809-test-bucket",
+          "type": "string"
+        },
+        "s3_bucket_lifecycle_configuration_rules": {
+          "sensitive": false,
+          "value": "",
+          "type": "string"
+        },
+        "s3_bucket_policy": {
+          "sensitive": false,
+          "value": "",
+          "type": "string"
+        },
+        "s3_bucket_region": {
+          "sensitive": false,
+          "value": "us-west-2",
+          "type": "string"
+        },
+        "s3_bucket_website_domain": {
+          "sensitive": false,
+          "value": "",
+          "type": "string"
+        },
+        "s3_bucket_website_endpoint": {
+          "sensitive": false,
+          "value": "",
+          "type": "string"
+        }
+      },
+      "root_module": {
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.test-bucket.data.aws_caller_identity.current",
+                "mode": "data",
+                "type": "aws_caller_identity",
+                "name": "current",
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "account_id": "616138583583",
+                  "arn": "arn:aws:sts::616138583583:assumed-role/AWSReservedSSO_AdministratorAccess_224e23fb315b65cb/anton@pulumi.com",
+                  "id": "616138583583",
+                  "user_id": "AROAY65FYVYP6E2HSUXEV:anton@pulumi.com"
+                },
+                "sensitive_values": {}
+              },
+              {
+                "address": "module.test-bucket.data.aws_partition.current",
+                "mode": "data",
+                "type": "aws_partition",
+                "name": "current",
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "dns_suffix": "amazonaws.com",
+                  "id": "aws",
+                  "partition": "aws",
+                  "reverse_dns_prefix": "com.amazonaws"
+                },
+                "sensitive_values": {}
+              },
+              {
+                "address": "module.test-bucket.data.aws_region.current",
+                "mode": "data",
+                "type": "aws_region",
+                "name": "current",
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "description": "US West (Oregon)",
+                  "endpoint": "ec2.us-west-2.amazonaws.com",
+                  "id": "us-west-2",
+                  "name": "us-west-2"
+                },
+                "sensitive_values": {}
+              },
+              {
+                "address": "module.test-bucket.aws_s3_bucket.this[0]",
+                "mode": "managed",
+                "type": "aws_s3_bucket",
+                "name": "this",
+                "index": 0,
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "acceleration_status": "",
+                  "acl": null,
+                  "arn": "arn:aws:s3:::852809-test-bucket",
+                  "bucket": "852809-test-bucket",
+                  "bucket_domain_name": "852809-test-bucket.s3.amazonaws.com",
+                  "bucket_prefix": "",
+                  "bucket_regional_domain_name": "852809-test-bucket.s3.us-west-2.amazonaws.com",
+                  "cors_rule": [],
+                  "force_destroy": false,
+                  "grant": [
+                    {
+                      "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                      "permissions": [
+                        "FULL_CONTROL"
+                      ],
+                      "type": "CanonicalUser",
+                      "uri": ""
+                    }
+                  ],
+                  "hosted_zone_id": "Z3BJ6K6RIION7M",
+                  "id": "852809-test-bucket",
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "object_lock_enabled": false,
+                  "policy": "",
+                  "region": "us-west-2",
+                  "replication_configuration": [],
+                  "request_payer": "BucketOwner",
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {
+                              "kms_master_key_id": "",
+                              "sse_algorithm": "AES256"
+                            }
+                          ],
+                          "bucket_key_enabled": false
+                        }
+                      ]
+                    }
+                  ],
+                  "tags": {},
+                  "tags_all": {},
+                  "timeouts": null,
+                  "versioning": [
+                    {
+                      "enabled": false,
+                      "mfa_delete": false
+                    }
+                  ],
+                  "website": [],
+                  "website_domain": null,
+                  "website_endpoint": null
+                },
+                "sensitive_values": {
+                  "cors_rule": [],
+                  "grant": [
+                    {
+                      "permissions": [
+                        false
+                      ]
+                    }
+                  ],
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "replication_configuration": [],
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "tags": {},
+                  "tags_all": {},
+                  "versioning": [
+                    {}
+                  ],
+                  "website": []
+                }
+              },
+              {
+                "address": "module.test-bucket.aws_s3_bucket_public_access_block.this[0]",
+                "mode": "managed",
+                "type": "aws_s3_bucket_public_access_block",
+                "name": "this",
+                "index": 0,
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "block_public_acls": true,
+                  "block_public_policy": true,
+                  "bucket": "852809-test-bucket",
+                  "id": "852809-test-bucket",
+                  "ignore_public_acls": true,
+                  "restrict_public_buckets": true
+                },
+                "sensitive_values": {},
+                "depends_on": [
+                  "module.test-bucket.aws_s3_bucket.this"
+                ]
+              },
+              {
+                "address": "module.test-bucket.aws_s3_bucket_server_side_encryption_configuration.this[0]",
+                "mode": "managed",
+                "type": "aws_s3_bucket_server_side_encryption_configuration",
+                "name": "this",
+                "index": 0,
+                "provider_name": "registry.opentofu.org/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "bucket": "852809-test-bucket",
+                  "expected_bucket_owner": "",
+                  "id": "852809-test-bucket",
+                  "rule": [
+                    {
+                      "apply_server_side_encryption_by_default": [
+                        {
+                          "kms_master_key_id": "",
+                          "sse_algorithm": "AES256"
+                        }
+                      ],
+                      "bucket_key_enabled": false
+                    }
+                  ]
+                },
+                "sensitive_values": {
+                  "rule": true
+                },
+                "depends_on": [
+                  "module.test-bucket.aws_s3_bucket.this"
+                ]
+              }
+            ],
+            "address": "module.test-bucket"
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "module.test-bucket:aws": {
+        "name": "aws",
+        "full_name": "registry.opentofu.org/hashicorp/aws",
+        "module_address": "module.test-bucket",
+        "version_constraint": "\u003e= 5.70.0"
+      }
+    },
+    "root_module": {
+      "outputs": {
+        "internal_output_is_secret_s3_bucket_arn": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_arn",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_bucket_domain_name": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_bucket_domain_name",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_bucket_regional_domain_name": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_bucket_regional_domain_name",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_hosted_zone_id": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_hosted_zone_id",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_id": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_id",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_lifecycle_configuration_rules": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_lifecycle_configuration_rules",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_policy": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_policy",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_region": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_region",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_website_domain": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_website_domain",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "internal_output_is_secret_s3_bucket_website_endpoint": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_website_endpoint",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_arn": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_arn",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_bucket_domain_name": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_bucket_domain_name",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_bucket_regional_domain_name": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_bucket_regional_domain_name",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_hosted_zone_id": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_hosted_zone_id",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_id": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_id",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_lifecycle_configuration_rules": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_lifecycle_configuration_rules",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_policy": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_policy",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_region": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_region",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_website_domain": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_website_domain",
+              "module.test-bucket"
+            ]
+          }
+        },
+        "s3_bucket_website_endpoint": {
+          "expression": {
+            "references": [
+              "module.test-bucket.s3_bucket_website_endpoint",
+              "module.test-bucket"
+            ]
+          }
+        }
+      },
+      "module_calls": {
+        "test-bucket": {
+          "source": "terraform-aws-modules/s3-bucket/aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "852809-test-bucket"
+            }
+          },
+          "module": {
+            "outputs": {
+              "s3_bucket_arn": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket.this[0].arn",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
+              },
+              "s3_bucket_bucket_domain_name": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket.this[0].bucket_domain_name",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The bucket domain name. Will be of format bucketname.s3.amazonaws.com."
+              },
+              "s3_bucket_bucket_regional_domain_name": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket.this[0].bucket_regional_domain_name",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL."
+              },
+              "s3_bucket_hosted_zone_id": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket.this[0].hosted_zone_id",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The Route 53 Hosted Zone ID for this bucket's region."
+              },
+              "s3_bucket_id": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket_policy.this[0].id",
+                    "aws_s3_bucket_policy.this[0]",
+                    "aws_s3_bucket_policy.this",
+                    "aws_s3_bucket.this[0].id",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The name of the bucket."
+              },
+              "s3_bucket_lifecycle_configuration_rules": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket_lifecycle_configuration.this[0].rule",
+                    "aws_s3_bucket_lifecycle_configuration.this[0]",
+                    "aws_s3_bucket_lifecycle_configuration.this"
+                  ]
+                },
+                "description": "The lifecycle rules of the bucket, if the bucket is configured with lifecycle rules. If not, this will be an empty string."
+              },
+              "s3_bucket_policy": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket_policy.this[0].policy",
+                    "aws_s3_bucket_policy.this[0]",
+                    "aws_s3_bucket_policy.this"
+                  ]
+                },
+                "description": "The policy of the bucket, if the bucket is configured with a policy. If not, this will be an empty string."
+              },
+              "s3_bucket_region": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket.this[0].region",
+                    "aws_s3_bucket.this[0]",
+                    "aws_s3_bucket.this"
+                  ]
+                },
+                "description": "The AWS region this bucket resides in."
+              },
+              "s3_bucket_website_domain": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket_website_configuration.this[0].website_domain",
+                    "aws_s3_bucket_website_configuration.this[0]",
+                    "aws_s3_bucket_website_configuration.this"
+                  ]
+                },
+                "description": "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records."
+              },
+              "s3_bucket_website_endpoint": {
+                "expression": {
+                  "references": [
+                    "aws_s3_bucket_website_configuration.this[0].website_endpoint",
+                    "aws_s3_bucket_website_configuration.this[0]",
+                    "aws_s3_bucket_website_configuration.this"
+                  ]
+                },
+                "description": "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string."
+              }
+            },
+            "resources": [
+              {
+                "address": "aws_s3_bucket.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "var.bucket"
+                    ]
+                  },
+                  "bucket_prefix": {
+                    "references": [
+                      "var.bucket_prefix"
+                    ]
+                  },
+                  "force_destroy": {
+                    "references": [
+                      "var.force_destroy"
+                    ]
+                  },
+                  "object_lock_enabled": {
+                    "references": [
+                      "var.object_lock_enabled"
+                    ]
+                  },
+                  "tags": {
+                    "references": [
+                      "var.tags"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_accelerate_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_accelerate_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  },
+                  "status": {
+                    "references": [
+                      "var.acceleration_status"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.acceleration_status"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_acl.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_acl",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "acl": {
+                    "references": [
+                      "var.acl",
+                      "var.acl"
+                    ]
+                  },
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.create_bucket_acl"
+                  ]
+                },
+                "depends_on": [
+                  "aws_s3_bucket_ownership_controls.this"
+                ]
+              },
+              {
+                "address": "aws_s3_bucket_analytics_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_analytics_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "each.key"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "for_each_expression": {
+                  "references": [
+                    "var.analytics_configuration",
+                    "local.create_bucket"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_cors_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_cors_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.cors_rules"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_intelligent_tiering_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_intelligent_tiering_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "each.key"
+                    ]
+                  },
+                  "status": {
+                    "references": [
+                      "each.value.status",
+                      "each.value",
+                      "each.value.status",
+                      "each.value"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "for_each_expression": {
+                  "references": [
+                    "local.intelligent_tiering",
+                    "local.create_bucket"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_inventory.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_inventory",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "each.value.bucket",
+                      "each.value",
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "destination": [
+                    {
+                      "bucket": [
+                        {
+                          "account_id": {
+                            "references": [
+                              "each.value.destination.account_id",
+                              "each.value.destination",
+                              "each.value"
+                            ]
+                          },
+                          "bucket_arn": {
+                            "references": [
+                              "each.value.destination.bucket_arn",
+                              "each.value.destination",
+                              "each.value",
+                              "aws_s3_bucket.this[0].arn",
+                              "aws_s3_bucket.this[0]",
+                              "aws_s3_bucket.this"
+                            ]
+                          },
+                          "format": {
+                            "references": [
+                              "each.value.destination.format",
+                              "each.value.destination",
+                              "each.value"
+                            ]
+                          },
+                          "prefix": {
+                            "references": [
+                              "each.value.destination.prefix",
+                              "each.value.destination",
+                              "each.value"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "enabled": {
+                    "references": [
+                      "each.value.enabled",
+                      "each.value"
+                    ]
+                  },
+                  "included_object_versions": {
+                    "references": [
+                      "each.value.included_object_versions",
+                      "each.value"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "each.key"
+                    ]
+                  },
+                  "optional_fields": {
+                    "references": [
+                      "each.value.optional_fields",
+                      "each.value"
+                    ]
+                  },
+                  "schedule": [
+                    {
+                      "frequency": {
+                        "references": [
+                          "each.value.frequency",
+                          "each.value"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "for_each_expression": {
+                  "references": [
+                    "var.inventory_configuration",
+                    "local.create_bucket"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_lifecycle_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_lifecycle_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  },
+                  "transition_default_minimum_object_size": {
+                    "references": [
+                      "var.transition_default_minimum_object_size"
+                    ]
+                  }
+                },
+                "schema_version": 1,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.lifecycle_rules"
+                  ]
+                },
+                "depends_on": [
+                  "aws_s3_bucket_versioning.this"
+                ]
+              },
+              {
+                "address": "aws_s3_bucket_logging.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_logging",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "target_bucket": {
+                    "references": [
+                      "var.logging[\"target_bucket\"]",
+                      "var.logging"
+                    ]
+                  },
+                  "target_prefix": {
+                    "references": [
+                      "var.logging[\"target_prefix\"]",
+                      "var.logging"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.logging"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_metric.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_metric",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "each.value.name",
+                      "each.value"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "for_each_expression": {
+                  "references": [
+                    "local.metric_configuration",
+                    "local.create_bucket"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_object_lock_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_object_lock_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  },
+                  "rule": [
+                    {
+                      "default_retention": [
+                        {
+                          "days": {
+                            "references": [
+                              "var.object_lock_configuration.rule.default_retention.days",
+                              "var.object_lock_configuration.rule.default_retention",
+                              "var.object_lock_configuration.rule",
+                              "var.object_lock_configuration"
+                            ]
+                          },
+                          "mode": {
+                            "references": [
+                              "var.object_lock_configuration.rule.default_retention.mode",
+                              "var.object_lock_configuration.rule.default_retention",
+                              "var.object_lock_configuration.rule",
+                              "var.object_lock_configuration"
+                            ]
+                          },
+                          "years": {
+                            "references": [
+                              "var.object_lock_configuration.rule.default_retention.years",
+                              "var.object_lock_configuration.rule.default_retention",
+                              "var.object_lock_configuration.rule",
+                              "var.object_lock_configuration"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "token": {
+                    "references": [
+                      "var.object_lock_configuration.token",
+                      "var.object_lock_configuration"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.object_lock_enabled",
+                    "var.object_lock_configuration.rule.default_retention",
+                    "var.object_lock_configuration.rule",
+                    "var.object_lock_configuration"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_ownership_controls.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_ownership_controls",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "local.attach_policy",
+                      "aws_s3_bucket_policy.this[0].id",
+                      "aws_s3_bucket_policy.this[0]",
+                      "aws_s3_bucket_policy.this",
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "rule": [
+                    {
+                      "object_ownership": {
+                        "references": [
+                          "var.object_ownership"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.control_object_ownership"
+                  ]
+                },
+                "depends_on": [
+                  "aws_s3_bucket_policy.this",
+                  "aws_s3_bucket_public_access_block.this",
+                  "aws_s3_bucket.this"
+                ]
+              },
+              {
+                "address": "aws_s3_bucket_policy.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_policy",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "policy": {
+                    "references": [
+                      "data.aws_iam_policy_document.combined[0].json",
+                      "data.aws_iam_policy_document.combined[0]",
+                      "data.aws_iam_policy_document.combined"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.attach_policy"
+                  ]
+                },
+                "depends_on": [
+                  "aws_s3_bucket_public_access_block.this"
+                ]
+              },
+              {
+                "address": "aws_s3_bucket_public_access_block.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_public_access_block",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "block_public_acls": {
+                    "references": [
+                      "var.block_public_acls"
+                    ]
+                  },
+                  "block_public_policy": {
+                    "references": [
+                      "var.block_public_policy"
+                    ]
+                  },
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "ignore_public_acls": {
+                    "references": [
+                      "var.ignore_public_acls"
+                    ]
+                  },
+                  "restrict_public_buckets": {
+                    "references": [
+                      "var.restrict_public_buckets"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_public_policy"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_replication_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_replication_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "role": {
+                    "references": [
+                      "var.replication_configuration[\"role\"]",
+                      "var.replication_configuration"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.replication_configuration"
+                  ]
+                },
+                "depends_on": [
+                  "aws_s3_bucket_versioning.this"
+                ]
+              },
+              {
+                "address": "aws_s3_bucket_request_payment_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_request_payment_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  },
+                  "payer": {
+                    "references": [
+                      "var.request_payer"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.request_payer"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_server_side_encryption_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_server_side_encryption_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.server_side_encryption_configuration"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_versioning.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_versioning",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  },
+                  "mfa": {
+                    "references": [
+                      "var.versioning[\"mfa\"]",
+                      "var.versioning"
+                    ]
+                  },
+                  "versioning_configuration": [
+                    {
+                      "mfa_delete": {
+                        "references": [
+                          "var.versioning[\"mfa_delete\"]",
+                          "var.versioning",
+                          "var.versioning[\"mfa_delete\"]",
+                          "var.versioning"
+                        ]
+                      },
+                      "status": {
+                        "references": [
+                          "var.versioning[\"enabled\"]",
+                          "var.versioning",
+                          "var.versioning[\"status\"]",
+                          "var.versioning",
+                          "var.versioning[\"status\"]",
+                          "var.versioning"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.versioning"
+                  ]
+                }
+              },
+              {
+                "address": "aws_s3_bucket_website_configuration.this",
+                "mode": "managed",
+                "type": "aws_s3_bucket_website_configuration",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "bucket": {
+                    "references": [
+                      "aws_s3_bucket.this[0].id",
+                      "aws_s3_bucket.this[0]",
+                      "aws_s3_bucket.this"
+                    ]
+                  },
+                  "expected_bucket_owner": {
+                    "references": [
+                      "var.expected_bucket_owner"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.website"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_caller_identity.current",
+                "mode": "data",
+                "type": "aws_caller_identity",
+                "name": "current",
+                "provider_config_key": "module.test-bucket:aws",
+                "schema_version": 0
+              },
+              {
+                "address": "data.aws_canonical_user_id.this",
+                "mode": "data",
+                "type": "aws_canonical_user_id",
+                "name": "this",
+                "provider_config_key": "module.test-bucket:aws",
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.create_bucket_acl",
+                    "var.owner[\"id\"]",
+                    "var.owner"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.access_log_delivery",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "access_log_delivery",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "logging.s3.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "AWSAccessLogDeliveryWrite"
+                      }
+                    },
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:GetBucketAcl"
+                        ]
+                      },
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "logging.s3.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "AWSAccessLogDeliveryAclCheck"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_access_log_delivery_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.combined",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "combined",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "source_policy_documents": {
+                    "references": [
+                      "var.attach_elb_log_delivery_policy",
+                      "data.aws_iam_policy_document.elb_log_delivery[0].json",
+                      "data.aws_iam_policy_document.elb_log_delivery[0]",
+                      "data.aws_iam_policy_document.elb_log_delivery",
+                      "var.attach_lb_log_delivery_policy",
+                      "data.aws_iam_policy_document.lb_log_delivery[0].json",
+                      "data.aws_iam_policy_document.lb_log_delivery[0]",
+                      "data.aws_iam_policy_document.lb_log_delivery",
+                      "var.attach_access_log_delivery_policy",
+                      "data.aws_iam_policy_document.access_log_delivery[0].json",
+                      "data.aws_iam_policy_document.access_log_delivery[0]",
+                      "data.aws_iam_policy_document.access_log_delivery",
+                      "var.attach_require_latest_tls_policy",
+                      "data.aws_iam_policy_document.require_latest_tls[0].json",
+                      "data.aws_iam_policy_document.require_latest_tls[0]",
+                      "data.aws_iam_policy_document.require_latest_tls",
+                      "var.attach_deny_insecure_transport_policy",
+                      "data.aws_iam_policy_document.deny_insecure_transport[0].json",
+                      "data.aws_iam_policy_document.deny_insecure_transport[0]",
+                      "data.aws_iam_policy_document.deny_insecure_transport",
+                      "var.attach_deny_unencrypted_object_uploads",
+                      "data.aws_iam_policy_document.deny_unencrypted_object_uploads[0].json",
+                      "data.aws_iam_policy_document.deny_unencrypted_object_uploads[0]",
+                      "data.aws_iam_policy_document.deny_unencrypted_object_uploads",
+                      "var.attach_deny_ssec_encrypted_object_uploads",
+                      "data.aws_iam_policy_document.deny_ssec_encrypted_object_uploads[0].json",
+                      "data.aws_iam_policy_document.deny_ssec_encrypted_object_uploads[0]",
+                      "data.aws_iam_policy_document.deny_ssec_encrypted_object_uploads",
+                      "var.attach_deny_incorrect_kms_key_sse",
+                      "data.aws_iam_policy_document.deny_incorrect_kms_key_sse[0].json",
+                      "data.aws_iam_policy_document.deny_incorrect_kms_key_sse[0]",
+                      "data.aws_iam_policy_document.deny_incorrect_kms_key_sse",
+                      "var.attach_deny_incorrect_encryption_headers",
+                      "data.aws_iam_policy_document.deny_incorrect_encryption_headers[0].json",
+                      "data.aws_iam_policy_document.deny_incorrect_encryption_headers[0]",
+                      "data.aws_iam_policy_document.deny_incorrect_encryption_headers",
+                      "var.attach_inventory_destination_policy",
+                      "var.attach_analytics_destination_policy",
+                      "data.aws_iam_policy_document.inventory_and_analytics_destination_policy[0].json",
+                      "data.aws_iam_policy_document.inventory_and_analytics_destination_policy[0]",
+                      "data.aws_iam_policy_document.inventory_and_analytics_destination_policy",
+                      "var.attach_policy",
+                      "var.policy"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "local.attach_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.deny_incorrect_encryption_headers",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "deny_incorrect_encryption_headers",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "StringNotEquals"
+                          },
+                          "values": {
+                            "references": [
+                              "var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm",
+                              "var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default",
+                              "var.server_side_encryption_configuration.rule",
+                              "var.server_side_encryption_configuration"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-server-side-encryption"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denyIncorrectEncryptionHeaders"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_deny_incorrect_encryption_headers"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.deny_incorrect_kms_key_sse",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "deny_incorrect_kms_key_sse",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "StringNotEquals"
+                          },
+                          "values": {
+                            "references": [
+                              "var.allowed_kms_key_arn"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-server-side-encryption-aws-kms-key-id"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denyIncorrectKmsKeySse"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_deny_incorrect_kms_key_sse"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.deny_insecure_transport",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "deny_insecure_transport",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:*"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "Bool"
+                          },
+                          "values": {
+                            "constant_value": [
+                              "false"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "aws:SecureTransport"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this",
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denyInsecureTransport"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_deny_insecure_transport_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.deny_ssec_encrypted_object_uploads",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "deny_ssec_encrypted_object_uploads",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "Null"
+                          },
+                          "values": {
+                            "constant_value": [
+                              false
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-server-side-encryption-customer-algorithm"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denySSECEncryptedObjectUploads"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_deny_ssec_encrypted_object_uploads"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.deny_unencrypted_object_uploads",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "deny_unencrypted_object_uploads",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "Null"
+                          },
+                          "values": {
+                            "constant_value": [
+                              true
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-server-side-encryption"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denyUnencryptedObjectUploads"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_deny_unencrypted_object_uploads"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.elb_log_delivery",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "elb_log_delivery",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "logdelivery.elasticloadbalancing.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": ""
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_elb_log_delivery_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.inventory_and_analytics_destination_policy",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "inventory_and_analytics_destination_policy",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "ArnLike"
+                          },
+                          "values": {
+                            "references": [
+                              "var.inventory_self_source_destination",
+                              "aws_s3_bucket.this[0].arn",
+                              "aws_s3_bucket.this[0]",
+                              "aws_s3_bucket.this",
+                              "var.inventory_source_bucket_arn",
+                              "var.analytics_self_source_destination",
+                              "aws_s3_bucket.this[0].arn",
+                              "aws_s3_bucket.this[0]",
+                              "aws_s3_bucket.this",
+                              "var.analytics_source_bucket_arn"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "aws:SourceArn"
+                          }
+                        },
+                        {
+                          "test": {
+                            "constant_value": "StringEquals"
+                          },
+                          "values": {
+                            "references": [
+                              "var.inventory_self_source_destination",
+                              "data.aws_caller_identity.current.id",
+                              "data.aws_caller_identity.current",
+                              "var.inventory_source_account_id",
+                              "var.analytics_self_source_destination",
+                              "data.aws_caller_identity.current.id",
+                              "data.aws_caller_identity.current",
+                              "var.analytics_source_account_id"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "aws:SourceAccount"
+                          }
+                        },
+                        {
+                          "test": {
+                            "constant_value": "StringEquals"
+                          },
+                          "values": {
+                            "constant_value": [
+                              "bucket-owner-full-control"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-acl"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "s3.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "destinationInventoryAndAnalyticsPolicy"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_inventory_destination_policy",
+                    "var.attach_analytics_destination_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.lb_log_delivery",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "lb_log_delivery",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:PutObject"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "StringEquals"
+                          },
+                          "values": {
+                            "constant_value": [
+                              "bucket-owner-full-control"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:x-amz-acl"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "delivery.logs.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "AWSLogDeliveryWrite"
+                      }
+                    },
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:GetBucketAcl",
+                          "s3:ListBucket"
+                        ]
+                      },
+                      "effect": {
+                        "constant_value": "Allow"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "delivery.logs.amazonaws.com"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "Service"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "AWSLogDeliveryAclCheck"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_lb_log_delivery_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_iam_policy_document.require_latest_tls",
+                "mode": "data",
+                "type": "aws_iam_policy_document",
+                "name": "require_latest_tls",
+                "provider_config_key": "module.test-bucket:aws",
+                "expressions": {
+                  "statement": [
+                    {
+                      "actions": {
+                        "constant_value": [
+                          "s3:*"
+                        ]
+                      },
+                      "condition": [
+                        {
+                          "test": {
+                            "constant_value": "NumericLessThan"
+                          },
+                          "values": {
+                            "constant_value": [
+                              "1.2"
+                            ]
+                          },
+                          "variable": {
+                            "constant_value": "s3:TlsVersion"
+                          }
+                        }
+                      ],
+                      "effect": {
+                        "constant_value": "Deny"
+                      },
+                      "principals": [
+                        {
+                          "identifiers": {
+                            "constant_value": [
+                              "*"
+                            ]
+                          },
+                          "type": {
+                            "constant_value": "*"
+                          }
+                        }
+                      ],
+                      "resources": {
+                        "references": [
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this",
+                          "aws_s3_bucket.this[0].arn",
+                          "aws_s3_bucket.this[0]",
+                          "aws_s3_bucket.this"
+                        ]
+                      },
+                      "sid": {
+                        "constant_value": "denyOutdatedTLS"
+                      }
+                    }
+                  ]
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "local.create_bucket",
+                    "var.attach_require_latest_tls_policy"
+                  ]
+                }
+              },
+              {
+                "address": "data.aws_partition.current",
+                "mode": "data",
+                "type": "aws_partition",
+                "name": "current",
+                "provider_config_key": "module.test-bucket:aws",
+                "schema_version": 0
+              },
+              {
+                "address": "data.aws_region.current",
+                "mode": "data",
+                "type": "aws_region",
+                "name": "current",
+                "provider_config_key": "module.test-bucket:aws",
+                "schema_version": 0
+              }
+            ],
+            "variables": {
+              "acceleration_status": {
+                "description": "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended."
+              },
+              "access_log_delivery_policy_source_accounts": {
+                "default": [],
+                "description": "(Optional) List of AWS Account IDs should be allowed to deliver access logs to this bucket."
+              },
+              "access_log_delivery_policy_source_buckets": {
+                "default": [],
+                "description": "(Optional) List of S3 bucket ARNs which should be allowed to deliver access logs to this bucket."
+              },
+              "acl": {
+                "description": "(Optional) The canned ACL to apply. Conflicts with `grant`"
+              },
+              "allowed_kms_key_arn": {
+                "description": "The ARN of KMS key which should be allowed in PutObject"
+              },
+              "analytics_configuration": {
+                "default": {},
+                "description": "Map containing bucket analytics configuration."
+              },
+              "analytics_self_source_destination": {
+                "default": false,
+                "description": "Whether or not the analytics source bucket is also the destination bucket."
+              },
+              "analytics_source_account_id": {
+                "description": "The analytics source account id."
+              },
+              "analytics_source_bucket_arn": {
+                "description": "The analytics source bucket ARN."
+              },
+              "attach_access_log_delivery_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have S3 access log delivery policy attached"
+              },
+              "attach_analytics_destination_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have bucket analytics destination policy attached."
+              },
+              "attach_deny_incorrect_encryption_headers": {
+                "default": false,
+                "description": "Controls if S3 bucket should deny incorrect encryption headers policy attached."
+              },
+              "attach_deny_incorrect_kms_key_sse": {
+                "default": false,
+                "description": "Controls if S3 bucket policy should deny usage of incorrect KMS key SSE."
+              },
+              "attach_deny_insecure_transport_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have deny non-SSL transport policy attached"
+              },
+              "attach_deny_ssec_encrypted_object_uploads": {
+                "default": false,
+                "description": "Controls if S3 bucket should deny SSEC encrypted object uploads."
+              },
+              "attach_deny_unencrypted_object_uploads": {
+                "default": false,
+                "description": "Controls if S3 bucket should deny unencrypted object uploads policy attached."
+              },
+              "attach_elb_log_delivery_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have ELB log delivery policy attached"
+              },
+              "attach_inventory_destination_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have bucket inventory destination policy attached."
+              },
+              "attach_lb_log_delivery_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have ALB/NLB log delivery policy attached"
+              },
+              "attach_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)"
+              },
+              "attach_public_policy": {
+                "default": true,
+                "description": "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)"
+              },
+              "attach_require_latest_tls_policy": {
+                "default": false,
+                "description": "Controls if S3 bucket should require the latest version of TLS"
+              },
+              "block_public_acls": {
+                "default": true,
+                "description": "Whether Amazon S3 should block public ACLs for this bucket."
+              },
+              "block_public_policy": {
+                "default": true,
+                "description": "Whether Amazon S3 should block public bucket policies for this bucket."
+              },
+              "bucket": {
+                "description": "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name."
+              },
+              "bucket_prefix": {
+                "description": "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket."
+              },
+              "control_object_ownership": {
+                "default": false,
+                "description": "Whether to manage S3 Bucket Ownership Controls on this bucket."
+              },
+              "cors_rule": {
+                "default": [],
+                "description": "List of maps containing rules for Cross-Origin Resource Sharing."
+              },
+              "create_bucket": {
+                "default": true,
+                "description": "Controls if S3 bucket should be created"
+              },
+              "expected_bucket_owner": {
+                "description": "The account ID of the expected bucket owner"
+              },
+              "force_destroy": {
+                "default": false,
+                "description": "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+              },
+              "grant": {
+                "default": [],
+                "description": "An ACL policy grant. Conflicts with `acl`"
+              },
+              "ignore_public_acls": {
+                "default": true,
+                "description": "Whether Amazon S3 should ignore public ACLs for this bucket."
+              },
+              "intelligent_tiering": {
+                "default": {},
+                "description": "Map containing intelligent tiering configuration."
+              },
+              "inventory_configuration": {
+                "default": {},
+                "description": "Map containing S3 inventory configuration."
+              },
+              "inventory_self_source_destination": {
+                "default": false,
+                "description": "Whether or not the inventory source bucket is also the destination bucket."
+              },
+              "inventory_source_account_id": {
+                "description": "The inventory source account id."
+              },
+              "inventory_source_bucket_arn": {
+                "description": "The inventory source bucket ARN."
+              },
+              "lifecycle_rule": {
+                "default": [],
+                "description": "List of maps containing configuration of object lifecycle management."
+              },
+              "logging": {
+                "default": {},
+                "description": "Map containing access bucket logging configuration."
+              },
+              "metric_configuration": {
+                "default": [],
+                "description": "Map containing bucket metric configuration."
+              },
+              "object_lock_configuration": {
+                "default": {},
+                "description": "Map containing S3 object locking configuration."
+              },
+              "object_lock_enabled": {
+                "default": false,
+                "description": "Whether S3 bucket should have an Object Lock configuration enabled."
+              },
+              "object_ownership": {
+                "default": "BucketOwnerEnforced",
+                "description": "Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. 'BucketOwnerEnforced': ACLs are disabled, and the bucket owner automatically owns and has full control over every object in the bucket. 'BucketOwnerPreferred': Objects uploaded to the bucket change ownership to the bucket owner if the objects are uploaded with the bucket-owner-full-control canned ACL. 'ObjectWriter': The uploading account will own the object if the object is uploaded with the bucket-owner-full-control canned ACL."
+              },
+              "owner": {
+                "default": {},
+                "description": "Bucket owner's display name and ID. Conflicts with `acl`"
+              },
+              "policy": {
+                "description": "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide."
+              },
+              "putin_khuylo": {
+                "default": true,
+                "description": "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
+              },
+              "replication_configuration": {
+                "default": {},
+                "description": "Map containing cross-region replication configuration."
+              },
+              "request_payer": {
+                "description": "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information."
+              },
+              "restrict_public_buckets": {
+                "default": true,
+                "description": "Whether Amazon S3 should restrict public bucket policies for this bucket."
+              },
+              "server_side_encryption_configuration": {
+                "default": {},
+                "description": "Map containing server-side encryption configuration."
+              },
+              "tags": {
+                "default": {},
+                "description": "(Optional) A mapping of tags to assign to the bucket."
+              },
+              "transition_default_minimum_object_size": {
+                "description": "The default minimum object size behavior applied to the lifecycle configuration. Valid values: all_storage_classes_128K (default), varies_by_storage_class"
+              },
+              "versioning": {
+                "default": {},
+                "description": "Map containing versioning configuration."
+              },
+              "website": {
+                "default": {},
+                "description": "Map containing static web-site hosting or redirect configuration."
+              }
+            }
+          },
+          "version_constraint": "4.5.0"
+        }
+      }
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "bucket_regional_domain_name"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "id"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "bucket_domain_name"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "arn"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "region"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket.this[0]",
+      "attribute": [
+        "hosted_zone_id"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket_lifecycle_configuration.this[0]",
+      "attribute": [
+        "rule"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket_policy.this[0]",
+      "attribute": [
+        "policy"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket_policy.this[0]",
+      "attribute": [
+        "id"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket_website_configuration.this[0]",
+      "attribute": [
+        "website_domain"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.aws_s3_bucket_website_configuration.this[0]",
+      "attribute": [
+        "website_endpoint"
+      ]
+    },
+    {
+      "resource": "module.test-bucket.data.aws_iam_policy_document.combined[0]",
+      "attribute": [
+        "json"
+      ]
+    }
+  ],
+  "timestamp": "2025-05-23T14:13:46Z"
+}

--- a/tests/schema_create_test.go
+++ b/tests/schema_create_test.go
@@ -619,9 +619,10 @@ func assertPlanForAddress(
 	assertFunc func(actual interface{}),
 ) {
 	t.Helper()
-	resourcePlan, ok := plan.FindResource(tfsandbox.ResourceAddress(address))
+	resourcePlan, ok := plan.FindResourcePlan(tfsandbox.ResourceAddress(address))
 	assert.Truef(t, ok, "resource %s not found", address)
-	values := resourcePlan.PlannedValues()
+	values, ok := resourcePlan.PlannedValues()
+	require.Truef(t, ok, "no planned values for this resource, possibly being deleted")
 	propertyPath, err := resource.ParsePropertyPath(property)
 	assert.NoErrorf(t, err, "error parsing property path %s", property)
 	propertyValue, ok := propertyPath.Get(resource.NewObjectProperty(values))


### PR DESCRIPTION
When working on the views feature I found that *tfsandbox.ResourcePlan object does not represent resource deletions. This is now fixed, and the ResourceStateOrPlan abstraction is removed as it is confusing and generally the two are not interchangeable.