### PR TITLE
[DO NOT MERGE] Switch tofu with terraform initial testing

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -89,3 +89,11 @@ runs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
       with:
         gradle-version: 7.6
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
+    - name: Show Terraform Version
+      shell: bash
+      run: |
+        terraform -version

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -17,7 +17,6 @@ package tfsandbox
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"path/filepath"
 	"testing"
@@ -28,91 +27,91 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func TestState(t *testing.T) {
-	ctx := context.Background()
-
-	tofu := newTestTofu(t)
-	t.Logf("WorkingDir: %s", tofu.WorkingDir())
-
-	outputs := []TFOutputSpec{
-		{Name: "output1"},
-		{Name: "sensitive_output"},
-		{Name: "statically_known"},
-	}
-
-	providersConfig := map[string]resource.PropertyMap{}
-	ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
-	err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
-		resource.NewPropertyMapFromMap(map[string]interface{}{
-			"inputVar": "test",
-		}), outputs, providersConfig)
-	require.NoError(t, err, "error creating tf file")
-
-	err = tofu.Init(ctx, DiscardLogger)
-	require.NoError(t, err, "error running tofu init")
-
-	initialPlan, err := tofu.Plan(ctx, DiscardLogger)
-	require.NoError(t, err, "error running tofu plan (before apply)")
-	require.NotNil(t, initialPlan, "expected a non-nil plan")
-
-	plannedOutputs := initialPlan.Outputs()
-	require.Equal(t, resource.PropertyMap{
-		resource.PropertyKey("output1"):          unknown(),
-		resource.PropertyKey("sensitive_output"): unknown(),
-		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
-	}, plannedOutputs)
-
-	state, err := tofu.Apply(ctx, DiscardLogger)
-	require.NoError(t, err, "error running tofu apply")
-
-	moduleOutputs := state.Outputs()
-	// output value is the same as the input
-	expectedOutputValue := resource.NewStringProperty("test")
-	require.Equal(t, resource.PropertyMap{
-		resource.PropertyKey("output1"):          expectedOutputValue,
-		resource.PropertyKey("sensitive_output"): resource.MakeSecret(expectedOutputValue),
-		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
-	}, moduleOutputs)
-
-	rawState, rawLockFile, err := tofu.PullStateAndLockFile(ctx)
-	require.NoError(t, err, "error pulling tofu state")
-
-	type stateModel struct {
-		Resources []any `json:"resources"`
-	}
-
-	var rawStateParsed stateModel
-	err = json.Unmarshal(rawState, &rawStateParsed)
-	require.NoError(t, err)
-
-	resourceCount := 0
-	state.VisitResourceStates(func(_ *ResourceState) {
-		resourceCount++
-	})
-
-	t.Logf("Found %d resources in state", resourceCount)
-
-	require.Equal(t, resourceCount, len(rawStateParsed.Resources))
-
-	// Now modify the state and run a plan.
-
-	newState := bytes.ReplaceAll(rawState, []byte(`"test"`), []byte(`"test2"`))
-	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
-	require.NoError(t, err, "error pushing tofu state")
-
-	plan, err := tofu.Plan(ctx, DiscardLogger)
-	require.NoError(t, err, "error replanning")
-
-	hasUpdates := false
-	plan.VisitResourcePlans(func(rp *ResourcePlan) {
-		if rp.ChangeKind() == Update {
-			hasUpdates = true
-			t.Logf("Planning to update %s", rp.Address())
-		}
-	})
-
-	require.True(t, hasUpdates, "expected the plan after the state edit to have updates")
-}
+//func TestState(t *testing.T) {
+//	ctx := context.Background()
+//
+//	tofu := newTestTofu(t)
+//	t.Logf("WorkingDir: %s", tofu.WorkingDir())
+//
+//	outputs := []TFOutputSpec{
+//		{Name: "output1"},
+//		{Name: "sensitive_output"},
+//		{Name: "statically_known"},
+//	}
+//
+//	providersConfig := map[string]resource.PropertyMap{}
+//	ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
+//	err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
+//		resource.NewPropertyMapFromMap(map[string]interface{}{
+//			"inputVar": "test",
+//		}), outputs, providersConfig)
+//	require.NoError(t, err, "error creating tf file")
+//
+//	err = tofu.Init(ctx, DiscardLogger)
+//	require.NoError(t, err, "error running tofu init")
+//
+//	initialPlan, err := tofu.Plan(ctx, DiscardLogger)
+//	require.NoError(t, err, "error running tofu plan (before apply)")
+//	require.NotNil(t, initialPlan, "expected a non-nil plan")
+//
+//	plannedOutputs := initialPlan.Outputs()
+//	require.Equal(t, resource.PropertyMap{
+//		resource.PropertyKey("output1"):          unknown(),
+//		resource.PropertyKey("sensitive_output"): unknown(),
+//		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
+//	}, plannedOutputs)
+//
+//	state, err := tofu.Apply(ctx, DiscardLogger)
+//	require.NoError(t, err, "error running tofu apply")
+//
+//	moduleOutputs := state.Outputs()
+//	// output value is the same as the input
+//	expectedOutputValue := resource.NewStringProperty("test")
+//	require.Equal(t, resource.PropertyMap{
+//		resource.PropertyKey("output1"):          expectedOutputValue,
+//		resource.PropertyKey("sensitive_output"): resource.MakeSecret(expectedOutputValue),
+//		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
+//	}, moduleOutputs)
+//
+//	rawState, rawLockFile, err := tofu.PullStateAndLockFile(ctx)
+//	require.NoError(t, err, "error pulling tofu state")
+//
+//	type stateModel struct {
+//		Resources []any `json:"resources"`
+//	}
+//
+//	var rawStateParsed stateModel
+//	err = json.Unmarshal(rawState, &rawStateParsed)
+//	require.NoError(t, err)
+//
+//	resourceCount := 0
+//	state.VisitResourceStates(func(_ *ResourceState) {
+//		resourceCount++
+//	})
+//
+//	t.Logf("Found %d resources in state", resourceCount)
+//
+//	require.Equal(t, resourceCount, len(rawStateParsed.Resources))
+//
+//	// Now modify the state and run a plan.
+//
+//	newState := bytes.ReplaceAll(rawState, []byte(`"test"`), []byte(`"test2"`))
+//	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
+//	require.NoError(t, err, "error pushing tofu state")
+//
+//	plan, err := tofu.Plan(ctx, DiscardLogger)
+//	require.NoError(t, err, "error replanning")
+//
+//	hasUpdates := false
+//	plan.VisitResourcePlans(func(rp *ResourcePlan) {
+//		if rp.ChangeKind() == Update {
+//			hasUpdates = true
+//			t.Logf("Planning to update %s", rp.Address())
+//		}
+//	})
+//
+//	require.True(t, hasUpdates, "expected the plan after the state edit to have updates")
+//}
 
 func TestStateMatchesPlan(t *testing.T) {
 	cases := []struct {

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -17,6 +17,7 @@ package tfsandbox
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"path/filepath"
 	"testing"
@@ -27,91 +28,91 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-//func TestState(t *testing.T) {
-//	ctx := context.Background()
-//
-//	tofu := newTestTofu(t)
-//	t.Logf("WorkingDir: %s", tofu.WorkingDir())
-//
-//	outputs := []TFOutputSpec{
-//		{Name: "output1"},
-//		{Name: "sensitive_output"},
-//		{Name: "statically_known"},
-//	}
-//
-//	providersConfig := map[string]resource.PropertyMap{}
-//	ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
-//	err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
-//		resource.NewPropertyMapFromMap(map[string]interface{}{
-//			"inputVar": "test",
-//		}), outputs, providersConfig)
-//	require.NoError(t, err, "error creating tf file")
-//
-//	err = tofu.Init(ctx, DiscardLogger)
-//	require.NoError(t, err, "error running tofu init")
-//
-//	initialPlan, err := tofu.Plan(ctx, DiscardLogger)
-//	require.NoError(t, err, "error running tofu plan (before apply)")
-//	require.NotNil(t, initialPlan, "expected a non-nil plan")
-//
-//	plannedOutputs := initialPlan.Outputs()
-//	require.Equal(t, resource.PropertyMap{
-//		resource.PropertyKey("output1"):          unknown(),
-//		resource.PropertyKey("sensitive_output"): unknown(),
-//		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
-//	}, plannedOutputs)
-//
-//	state, err := tofu.Apply(ctx, DiscardLogger)
-//	require.NoError(t, err, "error running tofu apply")
-//
-//	moduleOutputs := state.Outputs()
-//	// output value is the same as the input
-//	expectedOutputValue := resource.NewStringProperty("test")
-//	require.Equal(t, resource.PropertyMap{
-//		resource.PropertyKey("output1"):          expectedOutputValue,
-//		resource.PropertyKey("sensitive_output"): resource.MakeSecret(expectedOutputValue),
-//		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
-//	}, moduleOutputs)
-//
-//	rawState, rawLockFile, err := tofu.PullStateAndLockFile(ctx)
-//	require.NoError(t, err, "error pulling tofu state")
-//
-//	type stateModel struct {
-//		Resources []any `json:"resources"`
-//	}
-//
-//	var rawStateParsed stateModel
-//	err = json.Unmarshal(rawState, &rawStateParsed)
-//	require.NoError(t, err)
-//
-//	resourceCount := 0
-//	state.VisitResourceStates(func(_ *ResourceState) {
-//		resourceCount++
-//	})
-//
-//	t.Logf("Found %d resources in state", resourceCount)
-//
-//	require.Equal(t, resourceCount, len(rawStateParsed.Resources))
-//
-//	// Now modify the state and run a plan.
-//
-//	newState := bytes.ReplaceAll(rawState, []byte(`"test"`), []byte(`"test2"`))
-//	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
-//	require.NoError(t, err, "error pushing tofu state")
-//
-//	plan, err := tofu.Plan(ctx, DiscardLogger)
-//	require.NoError(t, err, "error replanning")
-//
-//	hasUpdates := false
-//	plan.VisitResourcePlans(func(rp *ResourcePlan) {
-//		if rp.ChangeKind() == Update {
-//			hasUpdates = true
-//			t.Logf("Planning to update %s", rp.Address())
-//		}
-//	})
-//
-//	require.True(t, hasUpdates, "expected the plan after the state edit to have updates")
-//}
+func TestState(t *testing.T) {
+	ctx := context.Background()
+
+	tofu := newTestTofu(t)
+	t.Logf("WorkingDir: %s", tofu.WorkingDir())
+
+	outputs := []TFOutputSpec{
+		{Name: "output1"},
+		{Name: "sensitive_output"},
+		{Name: "statically_known"},
+	}
+
+	providersConfig := map[string]resource.PropertyMap{}
+	ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
+	err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
+		resource.NewPropertyMapFromMap(map[string]interface{}{
+			"inputVar": "test",
+		}), outputs, providersConfig)
+	require.NoError(t, err, "error creating tf file")
+
+	err = tofu.Init(ctx, DiscardLogger)
+	require.NoError(t, err, "error running tofu init")
+
+	initialPlan, err := tofu.Plan(ctx, DiscardLogger)
+	require.NoError(t, err, "error running tofu plan (before apply)")
+	require.NotNil(t, initialPlan, "expected a non-nil plan")
+
+	plannedOutputs := initialPlan.Outputs()
+	require.Equal(t, resource.PropertyMap{
+		resource.PropertyKey("output1"):          unknown(),
+		resource.PropertyKey("sensitive_output"): unknown(),
+		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
+	}, plannedOutputs)
+
+	state, err := tofu.Apply(ctx, DiscardLogger)
+	require.NoError(t, err, "error running tofu apply")
+
+	moduleOutputs := state.Outputs()
+	// output value is the same as the input
+	expectedOutputValue := resource.NewStringProperty("test")
+	require.Equal(t, resource.PropertyMap{
+		resource.PropertyKey("output1"):          expectedOutputValue,
+		resource.PropertyKey("sensitive_output"): resource.MakeSecret(expectedOutputValue),
+		resource.PropertyKey("statically_known"): resource.NewStringProperty("static value"),
+	}, moduleOutputs)
+
+	rawState, rawLockFile, err := tofu.PullStateAndLockFile(ctx)
+	require.NoError(t, err, "error pulling tofu state")
+
+	type stateModel struct {
+		Resources []any `json:"resources"`
+	}
+
+	var rawStateParsed stateModel
+	err = json.Unmarshal(rawState, &rawStateParsed)
+	require.NoError(t, err)
+
+	resourceCount := 0
+	state.VisitResourceStates(func(_ *ResourceState) {
+		resourceCount++
+	})
+
+	t.Logf("Found %d resources in state", resourceCount)
+
+	require.Equal(t, resourceCount, len(rawStateParsed.Resources))
+
+	// Now modify the state and run a plan.
+
+	newState := bytes.ReplaceAll(rawState, []byte(`"test"`), []byte(`"test2"`))
+	err = tofu.PushStateAndLockFile(ctx, newState, rawLockFile)
+	require.NoError(t, err, "error pushing tofu state")
+
+	plan, err := tofu.Plan(ctx, DiscardLogger)
+	require.NoError(t, err, "error replanning")
+
+	hasUpdates := false
+	plan.VisitResourcePlans(func(rp *ResourcePlan) {
+		if rp.ChangeKind() == Update {
+			hasUpdates = true
+			t.Logf("Planning to update %s", rp.Address())
+		}
+	})
+
+	require.True(t, hasUpdates, "expected the plan after the state edit to have updates")
+}
 
 func TestStateMatchesPlan(t *testing.T) {
 	cases := []struct {

--- a/pkg/tfsandbox/tofu_test.go
+++ b/pkg/tfsandbox/tofu_test.go
@@ -35,7 +35,7 @@ func TestTofuInit(t *testing.T) {
 	t.Logf("Output: %s", res.String())
 
 	assert.NoError(t, err)
-	assert.Contains(t, res.String(), "OpenTofu initialized in an empty directory")
+	assert.Contains(t, res.String(), "initialized in an empty directory")
 }
 
 func TestTofuPlan(t *testing.T) {


### PR DESCRIPTION
Quick PR that uses `terraform` executable instead of `tofu` when initializing the sandbox to test it