### PR TITLE
Use the dev release of the CLI for views

### DIFF
--- a/scripts/install_views_pulumi_cli.sh
+++ b/scripts/install_views_pulumi_cli.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PULUMI_CLI_VERSION="pr#19467"
+PULUMI_CLI_VERSION="dev"
 DEST=".pulumi"
 
 if ! [ -x "$DEST/bin/pulumi" ]; then


### PR DESCRIPTION
The implementation is now available in pu/pu master, so we can use the latest dev release of the CLI for views tests.