### PR TITLE
Infer version from git and URL based module sources

### DIFF
--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -246,6 +246,20 @@ func parseParameterizeRequest(
 
 			if !isValidVersion(args[1]) {
 				// if the second arg is not a version then it must be package name
+				source := TFModuleSource(args[0])
+				if referencedVersion, ok := source.ReferencedVersionInURL(); ok && isValidVersion(referencedVersion) {
+					// here the source is remote but the version is specified in the URL
+					// usually this is a git URL with a ref query parameter
+					// we make sure that the version is valid because sometimes
+					// the ref query parameter refers to a branch
+					return applyConfigWhenAvailable(args[1], ParameterizeArgs{
+						TFModuleSource:  source,
+						TFModuleVersion: TFModuleVersion(referencedVersion),
+						PackageName:     packageName(args[1]),
+					})
+				}
+
+				// if the second arg is not a version then it must be package name
 				// but the source is remote so we need to resolve the version ourselves
 				latest, err := latestModuleVersion(ctx, args[0])
 				if err != nil {

--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -105,6 +105,21 @@ func TestParseParameterizeRequest(t *testing.T) {
 		assert.Equal(t, packageName("demoWebsite"), args.PackageName)
 	})
 
+	t.Run("parses github-based remote module source with version", func(t *testing.T) {
+		testRequest := &pulumirpc.ParameterizeRequest{
+			Parameters: &pulumirpc.ParameterizeRequest_Args{
+				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
+					Args: []string{"github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.21.0", "vpc"},
+				},
+			},
+		}
+		args, err := parseParameterizeRequest(ctx, testRequest)
+		assert.NoError(t, err)
+		assert.Equal(t, TFModuleSource("github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.21.0"), args.TFModuleSource)
+		assert.Equal(t, TFModuleVersion("5.21.0"), args.TFModuleVersion)
+		assert.Equal(t, packageName("vpc"), args.PackageName)
+	})
+
 	t.Run("fails on invalid module source", func(t *testing.T) {
 		testRequest := &pulumirpc.ParameterizeRequest{
 			Parameters: &pulumirpc.ParameterizeRequest_Args{

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -398,6 +398,51 @@ func TestInferModuleSchemaFromGitHubSourceWithSubModule(t *testing.T) {
 	}
 }
 
+func TestInferModuleSchemaFromGitHubSourceWithSubModuleAndVersion(t *testing.T) {
+	ctx := context.Background()
+	packageName := packageName("consulCluster")
+	executors := getExecutorsFromEnv()
+	for _, executor := range executors {
+		t.Run("executor="+executor, func(t *testing.T) {
+			tf := newTestRuntime(t, executor)
+			source := TFModuleSource("github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.11.0")
+			referencedVersion, ok := source.ReferencedVersionInURL()
+			assert.True(t, ok, "referenced version should be found in the source URL")
+			assert.Equal(t, "0.11.0", referencedVersion, "referenced version should be 0.11.0")
+			consulClusterSchema, err := InferModuleSchema(ctx,
+				tf,
+				packageName,
+				"github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.11.0",
+				TFModuleVersion(referencedVersion))
+
+			assert.NoError(t, err, "failed to infer module schema for github submodule")
+			assert.NotNil(t, consulClusterSchema, "inferred module schema for aws consul cluster submodule is nil")
+			// verify a sample of the inputs with different inferred types
+			expectedSampleInputs := map[string]*schema.PropertySpec{
+				"ami_id": {
+					Description: "The ID of the AMI to run in this cluster. " +
+						"Should be an AMI that had Consul installed and configured by the install-consul module.",
+					Secret:   false,
+					TypeSpec: stringType,
+				},
+				"spot_price": {
+					Description: "The maximum hourly price to pay for EC2 Spot Instances.",
+					Secret:      false,
+					TypeSpec:    numberType,
+				},
+			}
+
+			for name, expected := range expectedSampleInputs {
+				actual, ok := consulClusterSchema.Inputs[resource.PropertyKey(name)]
+				assert.True(t, ok, "input %s is missing from the schema", name)
+				assert.Equal(t, expected.Description, actual.Description, "input %s description is incorrect", name)
+				assert.Equal(t, expected.Secret, actual.Secret, "input %s secret is incorrect", name)
+				assert.Equal(t, expected.TypeSpec, actual.TypeSpec, "input %s type is incorrect", name)
+			}
+		})
+	}
+}
+
 func TestResolveModuleSources(t *testing.T) {
 	executors := getExecutorsFromEnv()
 	for _, executor := range executors {

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -141,8 +141,11 @@ func CreateTFFile(
 	moduleProps := map[string]interface{}{
 		"source": absoluteSource,
 	}
+
+	_, hasRef := source.ReferencedVersionInURL()
 	// local modules and github-based modules don't have a version
-	if version != "" {
+	// because setting a version is only valid for registry modules
+	if version != "" && !hasRef {
 		moduleProps["version"] = version
 	}
 

--- a/pkg/tfsandbox/types.go
+++ b/pkg/tfsandbox/types.go
@@ -1,6 +1,7 @@
 package tfsandbox
 
 import (
+	"net/url"
 	"strings"
 )
 
@@ -20,6 +21,19 @@ func (s TFModuleSource) IsLocalPath() bool {
 		return true
 	}
 	return false
+}
+
+// ReferencedVersionInURL returns the version reference in the module source URL, if any.
+// for example git::https://example.com/vpc.git?ref=v1.2.0 would return "1.2.0", true.
+func (s TFModuleSource) ReferencedVersionInURL() (string, bool) {
+	source := string(s)
+	parsedURL, err := url.Parse(source)
+	if err != nil {
+		return "", false
+	}
+
+	ref := strings.TrimPrefix(parsedURL.Query().Get("ref"), "v")
+	return ref, ref != ""
 }
 
 // Version specification for a Terraform module, for example "5.16.0".


### PR DESCRIPTION
Resolves #369 

Extracting module version from git / URL sources that define the version in `?ref=<version>` query parameter and ensuring that we don't set an explicit version in the TF file we write because a version is only valid for registry-based modules. 