### PR TITLE
Better missing credentials error when using AWS modules

### DIFF
--- a/pkg/modprovider/error_message.go
+++ b/pkg/modprovider/error_message.go
@@ -1,0 +1,20 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modprovider
+
+import _ "embed"
+
+//go:embed error_messages/aws_missing_credentials_error.txt
+var awsMissingCredentialsErrorMessage string

--- a/pkg/modprovider/error_messages/aws_missing_credentials_error.txt
+++ b/pkg/modprovider/error_messages/aws_missing_credentials_error.txt
@@ -1,0 +1,6 @@
+no valid credentials source found to configure the AWS provider.
+Consider supplying the required AWS credentials to the provider either via environment variables,
+or by configuring the provider explicitly in the Pulumi program with an explicit provider resource.
+See https://github.com/pulumi/pulumi-terraform-module?tab=readme-ov-file#configuring-terraform-providers.
+Alternatively, you can use Pulumi ESC to set up dynamic credentials with AWS OIDC.
+Learn more: https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials-via-pulumi-esc

--- a/pkg/modprovider/logger.go
+++ b/pkg/modprovider/logger.go
@@ -131,16 +131,7 @@ func (l *resourceLogger) Log(ctx context.Context, level tfsandbox.LogLevel, mess
 	if diagLevel == diag.Error && isMissingCredentialsErrorFromAWS(message) {
 		// for AWS provider, we can detect missing credentials errors and provide a more helpful message
 		// that is specific to Pulumi users.
-		modifiedCredentialsError := []string{
-			"no valid credentials source found to configure the AWS provider.",
-			"Consider supplying the required AWS credentials to the provider either via environment variables,",
-			"or by configuring the provider explicitly in the Pulumi program with an explicit provider resource.",
-			"Alternatively, you can use Pulumi ESC to set up dynamic credentials with AWS OIDC.",
-			//nolint:all
-			"Learn more: https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials-via-pulumi-esc",
-		}
-
-		message = strings.Join(modifiedCredentialsError, "\n")
+		message = awsMissingCredentialsErrorMessage
 	}
 
 	err = l.hc.Log(ctx, diagLevel, l.urn, message)

--- a/pkg/modprovider/logger.go
+++ b/pkg/modprovider/logger.go
@@ -16,6 +16,7 @@ package modprovider
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -101,6 +102,12 @@ func newResourceLogger(hc *provider.HostClient, urn resource.URN) tfsandbox.Logg
 	return &resourceLogger{hc: hc, urn: urn}
 }
 
+func isMissingCredentialsErrorFromAWS(message string) bool {
+	topLevelError := strings.Contains(message, "No valid credential sources found") ||
+		strings.Contains(message, "Invalid provider configuration")
+	return topLevelError && strings.Contains(message, "hashicorp/aws")
+}
+
 func (l *resourceLogger) Log(ctx context.Context, level tfsandbox.LogLevel, message string) {
 	if l.hc == nil {
 		return
@@ -119,6 +126,21 @@ func (l *resourceLogger) Log(ctx context.Context, level tfsandbox.LogLevel, mess
 		diagLevel = diag.Error
 	default:
 		diagLevel = diag.Info
+	}
+
+	if diagLevel == diag.Error && isMissingCredentialsErrorFromAWS(message) {
+		// for AWS provider, we can detect missing credentials errors and provide a more helpful message
+		// that is specific to Pulumi users.
+		modifiedCredentialsError := []string{
+			"no valid credentials source found to configure the AWS provider.",
+			"Consider supplying the required AWS credentials to the provider either via environment variables,",
+			"or by configuring the provider explicitly in the Pulumi program with an explicit provider resource.",
+			"Alternatively, you can use Pulumi ESC to set up dynamic credentials with AWS OIDC.",
+			//nolint:all
+			"Learn more: https://www.pulumi.com/registry/packages/aws/installation-configuration/#dynamically-generate-credentials-via-pulumi-esc",
+		}
+
+		message = strings.Join(modifiedCredentialsError, "\n")
 	}
 
 	err = l.hc.Log(ctx, diagLevel, l.urn, message)


### PR DESCRIPTION
Resolves #197 

When using terraform AWS modules without credentials, we see an error that is terraform-specific and not actionable for Pulumi users. This missing credentials error is issued as an error log message. This PR intercepts logs to detect that error and return a nicer Pulumi-specific error similar to how we implemented it in pulumi-aws.  