### PR TITLE
Fix VPC module typings, include outputs that refer to serialized resources

### DIFF
--- a/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
+++ b/pkg/modprovider/module_schema_overrides/terraform-aws-vpc.json
@@ -75,6 +75,15 @@
             "type": "string"
           }
         },
+        "private_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
+          }
+        },
         "private_subnet_arns": {
           "type": "array",
           "items": {
@@ -97,6 +106,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "public_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
           }
         },
         "public_subnet_arns": {
@@ -127,6 +145,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "outpost_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
           }
         },
         "outpost_subnets_cidr_blocks": {
@@ -165,6 +192,15 @@
             "type": "string"
           }
         },
+        "database_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
+          }
+        },
         "database_subnet_group": {
           "type": "string"
         },
@@ -175,6 +211,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "redshift_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
           }
         },
         "redshift_subnet_arns": {
@@ -202,6 +247,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "elasticache_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
           }
         },
         "elasticache_subnet_arns": {
@@ -232,6 +286,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "intra_subnet_objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            }
           }
         },
         "intra_subnet_arns": {


### PR DESCRIPTION
Small part of #329 starting by fixing the typings for the outputs. There are outputs that refer to a list of resources so I've modelled them here as `list(map(string, any))` instead of `list(any)` so that they are slightly more usable. In the meantime, looking at python sdk changes