### PR TITLE
Default output type is any, better inference for try(...) expressions

### DIFF
--- a/tests/testdata/aws-vpc/go-views/sdks/vpc/vpc/module.go
+++ b/tests/testdata/aws-vpc/go-views/sdks/vpc/vpc/module.go
@@ -41,7 +41,7 @@ type Module struct {
 	// Name of database subnet group
 	Database_subnet_group_name pulumi.StringPtrOutput `pulumi:"database_subnet_group_name"`
 	// A list of all database subnets, containing the full objects.
-	Database_subnet_objects pulumi.StringPtrOutput `pulumi:"database_subnet_objects"`
+	Database_subnet_objects pulumi.MapArrayOutput `pulumi:"database_subnet_objects"`
 	// List of IDs of database subnets
 	Database_subnets pulumi.StringArrayOutput `pulumi:"database_subnets"`
 	// List of cidr_blocks of database subnets
@@ -93,7 +93,7 @@ type Module struct {
 	// Name of elasticache subnet group
 	Elasticache_subnet_group_name pulumi.StringPtrOutput `pulumi:"elasticache_subnet_group_name"`
 	// A list of all elasticache subnets, containing the full objects.
-	Elasticache_subnet_objects pulumi.StringPtrOutput `pulumi:"elasticache_subnet_objects"`
+	Elasticache_subnet_objects pulumi.MapArrayOutput `pulumi:"elasticache_subnet_objects"`
 	// List of IDs of elasticache subnets
 	Elasticache_subnets pulumi.StringArrayOutput `pulumi:"elasticache_subnets"`
 	// List of cidr_blocks of elasticache subnets
@@ -115,7 +115,7 @@ type Module struct {
 	// List of ARNs of intra subnets
 	Intra_subnet_arns pulumi.StringArrayOutput `pulumi:"intra_subnet_arns"`
 	// A list of all intra subnets, containing the full objects.
-	Intra_subnet_objects pulumi.StringPtrOutput `pulumi:"intra_subnet_objects"`
+	Intra_subnet_objects pulumi.MapArrayOutput `pulumi:"intra_subnet_objects"`
 	// List of IDs of intra subnets
 	Intra_subnets pulumi.StringArrayOutput `pulumi:"intra_subnets"`
 	// List of cidr_blocks of intra subnets
@@ -139,7 +139,7 @@ type Module struct {
 	// List of ARNs of outpost subnets
 	Outpost_subnet_arns pulumi.StringArrayOutput `pulumi:"outpost_subnet_arns"`
 	// A list of all outpost subnets, containing the full objects.
-	Outpost_subnet_objects pulumi.StringPtrOutput `pulumi:"outpost_subnet_objects"`
+	Outpost_subnet_objects pulumi.MapArrayOutput `pulumi:"outpost_subnet_objects"`
 	// List of IDs of outpost subnets
 	Outpost_subnets pulumi.StringArrayOutput `pulumi:"outpost_subnets"`
 	// List of cidr_blocks of outpost subnets
@@ -161,7 +161,7 @@ type Module struct {
 	// List of ARNs of private subnets
 	Private_subnet_arns pulumi.StringArrayOutput `pulumi:"private_subnet_arns"`
 	// A list of all private subnets, containing the full objects.
-	Private_subnet_objects pulumi.StringPtrOutput `pulumi:"private_subnet_objects"`
+	Private_subnet_objects pulumi.MapArrayOutput `pulumi:"private_subnet_objects"`
 	// List of IDs of private subnets
 	Private_subnets pulumi.StringArrayOutput `pulumi:"private_subnets"`
 	// List of cidr_blocks of private subnets
@@ -183,7 +183,7 @@ type Module struct {
 	// List of ARNs of public subnets
 	Public_subnet_arns pulumi.StringArrayOutput `pulumi:"public_subnet_arns"`
 	// A list of all public subnets, containing the full objects.
-	Public_subnet_objects pulumi.StringPtrOutput `pulumi:"public_subnet_objects"`
+	Public_subnet_objects pulumi.MapArrayOutput `pulumi:"public_subnet_objects"`
 	// List of IDs of public subnets
 	Public_subnets pulumi.StringArrayOutput `pulumi:"public_subnets"`
 	// List of cidr_blocks of public subnets
@@ -205,7 +205,7 @@ type Module struct {
 	// ID of redshift subnet group
 	Redshift_subnet_group pulumi.StringPtrOutput `pulumi:"redshift_subnet_group"`
 	// A list of all redshift subnets, containing the full objects.
-	Redshift_subnet_objects pulumi.StringPtrOutput `pulumi:"redshift_subnet_objects"`
+	Redshift_subnet_objects pulumi.MapArrayOutput `pulumi:"redshift_subnet_objects"`
 	// List of IDs of redshift subnets
 	Redshift_subnets pulumi.StringArrayOutput `pulumi:"redshift_subnets"`
 	// List of cidr_blocks of redshift subnets
@@ -228,11 +228,11 @@ type Module struct {
 	// Whether or not the VPC has DNS support
 	Vpc_enable_dns_support pulumi.BoolPtrOutput `pulumi:"vpc_enable_dns_support"`
 	// The ARN of the IAM role used when pushing logs to Cloudwatch log group
-	Vpc_flow_log_cloudwatch_iam_role_arn pulumi.StringPtrOutput `pulumi:"vpc_flow_log_cloudwatch_iam_role_arn"`
+	Vpc_flow_log_cloudwatch_iam_role_arn pulumi.AnyOutput `pulumi:"vpc_flow_log_cloudwatch_iam_role_arn"`
 	// The ARN of the IAM role used when pushing logs cross account
 	Vpc_flow_log_deliver_cross_account_role pulumi.StringPtrOutput `pulumi:"vpc_flow_log_deliver_cross_account_role"`
 	// The ARN of the destination for VPC Flow Logs
-	Vpc_flow_log_destination_arn pulumi.StringPtrOutput `pulumi:"vpc_flow_log_destination_arn"`
+	Vpc_flow_log_destination_arn pulumi.AnyOutput `pulumi:"vpc_flow_log_destination_arn"`
 	// The type of the destination for VPC Flow Logs
 	Vpc_flow_log_destination_type pulumi.StringPtrOutput `pulumi:"vpc_flow_log_destination_type"`
 	// The ID of the Flow Log resource
@@ -1338,8 +1338,8 @@ func (o ModuleOutput) Database_subnet_group_name() pulumi.StringPtrOutput {
 }
 
 // A list of all database subnets, containing the full objects.
-func (o ModuleOutput) Database_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Database_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Database_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Database_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of database subnets
@@ -1468,8 +1468,8 @@ func (o ModuleOutput) Elasticache_subnet_group_name() pulumi.StringPtrOutput {
 }
 
 // A list of all elasticache subnets, containing the full objects.
-func (o ModuleOutput) Elasticache_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Elasticache_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Elasticache_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Elasticache_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of elasticache subnets
@@ -1523,8 +1523,8 @@ func (o ModuleOutput) Intra_subnet_arns() pulumi.StringArrayOutput {
 }
 
 // A list of all intra subnets, containing the full objects.
-func (o ModuleOutput) Intra_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Intra_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Intra_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Intra_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of intra subnets
@@ -1583,8 +1583,8 @@ func (o ModuleOutput) Outpost_subnet_arns() pulumi.StringArrayOutput {
 }
 
 // A list of all outpost subnets, containing the full objects.
-func (o ModuleOutput) Outpost_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Outpost_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Outpost_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Outpost_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of outpost subnets
@@ -1638,8 +1638,8 @@ func (o ModuleOutput) Private_subnet_arns() pulumi.StringArrayOutput {
 }
 
 // A list of all private subnets, containing the full objects.
-func (o ModuleOutput) Private_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Private_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Private_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Private_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of private subnets
@@ -1693,8 +1693,8 @@ func (o ModuleOutput) Public_subnet_arns() pulumi.StringArrayOutput {
 }
 
 // A list of all public subnets, containing the full objects.
-func (o ModuleOutput) Public_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Public_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Public_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Public_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of public subnets
@@ -1748,8 +1748,8 @@ func (o ModuleOutput) Redshift_subnet_group() pulumi.StringPtrOutput {
 }
 
 // A list of all redshift subnets, containing the full objects.
-func (o ModuleOutput) Redshift_subnet_objects() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Redshift_subnet_objects }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Redshift_subnet_objects() pulumi.MapArrayOutput {
+	return o.ApplyT(func(v *Module) pulumi.MapArrayOutput { return v.Redshift_subnet_objects }).(pulumi.MapArrayOutput)
 }
 
 // List of IDs of redshift subnets
@@ -1807,8 +1807,8 @@ func (o ModuleOutput) Vpc_enable_dns_support() pulumi.BoolPtrOutput {
 }
 
 // The ARN of the IAM role used when pushing logs to Cloudwatch log group
-func (o ModuleOutput) Vpc_flow_log_cloudwatch_iam_role_arn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_flow_log_cloudwatch_iam_role_arn }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Vpc_flow_log_cloudwatch_iam_role_arn() pulumi.AnyOutput {
+	return o.ApplyT(func(v *Module) pulumi.AnyOutput { return v.Vpc_flow_log_cloudwatch_iam_role_arn }).(pulumi.AnyOutput)
 }
 
 // The ARN of the IAM role used when pushing logs cross account
@@ -1817,8 +1817,8 @@ func (o ModuleOutput) Vpc_flow_log_deliver_cross_account_role() pulumi.StringPtr
 }
 
 // The ARN of the destination for VPC Flow Logs
-func (o ModuleOutput) Vpc_flow_log_destination_arn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Module) pulumi.StringPtrOutput { return v.Vpc_flow_log_destination_arn }).(pulumi.StringPtrOutput)
+func (o ModuleOutput) Vpc_flow_log_destination_arn() pulumi.AnyOutput {
+	return o.ApplyT(func(v *Module) pulumi.AnyOutput { return v.Vpc_flow_log_destination_arn }).(pulumi.AnyOutput)
 }
 
 // The type of the destination for VPC Flow Logs

--- a/tests/testdata/aws-vpc/go-views/sdks/vpc/vpc/provider.go
+++ b/tests/testdata/aws-vpc/go-views/sdks/vpc/vpc/provider.go
@@ -22,6 +22,11 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
+	if args.Executor == nil {
+		if d := internal.GetEnvOrDefault("", nil, "PULUMI_TERRAFORM_MODULE_EXECUTOR"); d != nil {
+			args.Executor = pulumi.StringPtr(d.(string))
+		}
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	ref, err := internal.PkgGetPackageRef(ctx)
 	if err != nil {
@@ -38,12 +43,16 @@ func NewProvider(ctx *pulumi.Context,
 type providerArgs struct {
 	// provider configuration for aws
 	Aws map[string]interface{} `pulumi:"aws"`
+	// Sets the executor used to run the module.
+	Executor *string `pulumi:"executor"`
 }
 
 // The set of arguments for constructing a Provider resource.
 type ProviderArgs struct {
 	// provider configuration for aws
 	Aws pulumi.MapInput
+	// Sets the executor used to run the module.
+	Executor pulumi.StringPtrInput
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/tests/testdata/aws-vpc/java-views/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
+++ b/tests/testdata/aws-vpc/java-views/sdks/vpc/src/main/java/com/pulumi/vpc/Module.java
@@ -205,14 +205,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all database subnets, containing the full objects.
      * 
      */
-    @Export(name="database_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> database_subnet_objects;
+    @Export(name="database_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> database_subnet_objects;
 
     /**
      * @return A list of all database subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> database_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> database_subnet_objects() {
         return Codegen.optional(this.database_subnet_objects);
     }
     /**
@@ -569,14 +569,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all elasticache subnets, containing the full objects.
      * 
      */
-    @Export(name="elasticache_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> elasticache_subnet_objects;
+    @Export(name="elasticache_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> elasticache_subnet_objects;
 
     /**
      * @return A list of all elasticache subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> elasticache_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> elasticache_subnet_objects() {
         return Codegen.optional(this.elasticache_subnet_objects);
     }
     /**
@@ -723,14 +723,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all intra subnets, containing the full objects.
      * 
      */
-    @Export(name="intra_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> intra_subnet_objects;
+    @Export(name="intra_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> intra_subnet_objects;
 
     /**
      * @return A list of all intra subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> intra_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> intra_subnet_objects() {
         return Codegen.optional(this.intra_subnet_objects);
     }
     /**
@@ -891,14 +891,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all outpost subnets, containing the full objects.
      * 
      */
-    @Export(name="outpost_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> outpost_subnet_objects;
+    @Export(name="outpost_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> outpost_subnet_objects;
 
     /**
      * @return A list of all outpost subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> outpost_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> outpost_subnet_objects() {
         return Codegen.optional(this.outpost_subnet_objects);
     }
     /**
@@ -1045,14 +1045,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all private subnets, containing the full objects.
      * 
      */
-    @Export(name="private_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> private_subnet_objects;
+    @Export(name="private_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> private_subnet_objects;
 
     /**
      * @return A list of all private subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> private_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> private_subnet_objects() {
         return Codegen.optional(this.private_subnet_objects);
     }
     /**
@@ -1199,14 +1199,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all public subnets, containing the full objects.
      * 
      */
-    @Export(name="public_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> public_subnet_objects;
+    @Export(name="public_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> public_subnet_objects;
 
     /**
      * @return A list of all public subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> public_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> public_subnet_objects() {
         return Codegen.optional(this.public_subnet_objects);
     }
     /**
@@ -1353,14 +1353,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * A list of all redshift subnets, containing the full objects.
      * 
      */
-    @Export(name="redshift_subnet_objects", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> redshift_subnet_objects;
+    @Export(name="redshift_subnet_objects", refs={List.class,Map.class,String.class,Object.class}, tree="[0,[1,2,3]]")
+    private Output</* @Nullable */ List<Map<String,Object>>> redshift_subnet_objects;
 
     /**
      * @return A list of all redshift subnets, containing the full objects.
      * 
      */
-    public Output<Optional<String>> redshift_subnet_objects() {
+    public Output<Optional<List<Map<String,Object>>>> redshift_subnet_objects() {
         return Codegen.optional(this.redshift_subnet_objects);
     }
     /**
@@ -1513,14 +1513,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * The ARN of the IAM role used when pushing logs to Cloudwatch log group
      * 
      */
-    @Export(name="vpc_flow_log_cloudwatch_iam_role_arn", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> vpc_flow_log_cloudwatch_iam_role_arn;
+    @Export(name="vpc_flow_log_cloudwatch_iam_role_arn", refs={Object.class}, tree="[0]")
+    private Output</* @Nullable */ Object> vpc_flow_log_cloudwatch_iam_role_arn;
 
     /**
      * @return The ARN of the IAM role used when pushing logs to Cloudwatch log group
      * 
      */
-    public Output<Optional<String>> vpc_flow_log_cloudwatch_iam_role_arn() {
+    public Output<Optional<Object>> vpc_flow_log_cloudwatch_iam_role_arn() {
         return Codegen.optional(this.vpc_flow_log_cloudwatch_iam_role_arn);
     }
     /**
@@ -1541,14 +1541,14 @@ public class Module extends com.pulumi.resources.CustomResource {
      * The ARN of the destination for VPC Flow Logs
      * 
      */
-    @Export(name="vpc_flow_log_destination_arn", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> vpc_flow_log_destination_arn;
+    @Export(name="vpc_flow_log_destination_arn", refs={Object.class}, tree="[0]")
+    private Output</* @Nullable */ Object> vpc_flow_log_destination_arn;
 
     /**
      * @return The ARN of the destination for VPC Flow Logs
      * 
      */
-    public Output<Optional<String>> vpc_flow_log_destination_arn() {
+    public Output<Optional<Object>> vpc_flow_log_destination_arn() {
         return Codegen.optional(this.vpc_flow_log_destination_arn);
     }
     /**

--- a/tests/testdata/aws-vpc/java-views/sdks/vpc/src/main/java/com/pulumi/vpc/ProviderArgs.java
+++ b/tests/testdata/aws-vpc/java-views/sdks/vpc/src/main/java/com/pulumi/vpc/ProviderArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.vpc;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import java.lang.Object;
 import java.lang.String;
 import java.util.Map;
@@ -32,10 +33,26 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.aws);
     }
 
+    /**
+     * Sets the executor used to run the module.
+     * 
+     */
+    @Import(name="executor")
+    private @Nullable Output<String> executor;
+
+    /**
+     * @return Sets the executor used to run the module.
+     * 
+     */
+    public Optional<Output<String>> executor() {
+        return Optional.ofNullable(this.executor);
+    }
+
     private ProviderArgs() {}
 
     private ProviderArgs(ProviderArgs $) {
         this.aws = $.aws;
+        this.executor = $.executor;
     }
 
     public static Builder builder() {
@@ -77,7 +94,29 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
             return aws(Output.of(aws));
         }
 
+        /**
+         * @param executor Sets the executor used to run the module.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder executor(@Nullable Output<String> executor) {
+            $.executor = executor;
+            return this;
+        }
+
+        /**
+         * @param executor Sets the executor used to run the module.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder executor(String executor) {
+            return executor(Output.of(executor));
+        }
+
         public ProviderArgs build() {
+            $.executor = Codegen.stringProp("executor").output().arg($.executor).env("PULUMI_TERRAFORM_MODULE_EXECUTOR").def("").getNullable();
             return $;
         }
     }

--- a/tests/testdata/aws-vpc/node-views/sdks/vpc/module.ts
+++ b/tests/testdata/aws-vpc/node-views/sdks/vpc/module.ts
@@ -88,7 +88,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all database subnets, containing the full objects.
      */
-    public /*out*/ readonly database_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly database_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of database subnets
      */
@@ -192,7 +192,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all elasticache subnets, containing the full objects.
      */
-    public /*out*/ readonly elasticache_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly elasticache_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of elasticache subnets
      */
@@ -236,7 +236,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all intra subnets, containing the full objects.
      */
-    public /*out*/ readonly intra_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly intra_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of intra subnets
      */
@@ -284,7 +284,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all outpost subnets, containing the full objects.
      */
-    public /*out*/ readonly outpost_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly outpost_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of outpost subnets
      */
@@ -328,7 +328,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all private subnets, containing the full objects.
      */
-    public /*out*/ readonly private_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly private_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of private subnets
      */
@@ -372,7 +372,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all public subnets, containing the full objects.
      */
-    public /*out*/ readonly public_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly public_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of public subnets
      */
@@ -416,7 +416,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * A list of all redshift subnets, containing the full objects.
      */
-    public /*out*/ readonly redshift_subnet_objects!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly redshift_subnet_objects!: pulumi.Output<{[key: string]: any}[] | undefined>;
     /**
      * List of IDs of redshift subnets
      */
@@ -461,7 +461,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * The ARN of the IAM role used when pushing logs to Cloudwatch log group
      */
-    public /*out*/ readonly vpc_flow_log_cloudwatch_iam_role_arn!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_flow_log_cloudwatch_iam_role_arn!: pulumi.Output<any | undefined>;
     /**
      * The ARN of the IAM role used when pushing logs cross account
      */
@@ -469,7 +469,7 @@ export class Module extends pulumi.CustomResource {
     /**
      * The ARN of the destination for VPC Flow Logs
      */
-    public /*out*/ readonly vpc_flow_log_destination_arn!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly vpc_flow_log_destination_arn!: pulumi.Output<any | undefined>;
     /**
      * The type of the destination for VPC Flow Logs
      */

--- a/tests/testdata/aws-vpc/node-views/sdks/vpc/provider.ts
+++ b/tests/testdata/aws-vpc/node-views/sdks/vpc/provider.ts
@@ -32,6 +32,7 @@ export class Provider extends pulumi.ProviderResource {
         opts = opts || {};
         {
             resourceInputs["aws"] = pulumi.output(args ? args.aws : undefined).apply(JSON.stringify);
+            resourceInputs["executor"] = (args ? args.executor : undefined) ?? (utilities.getEnv("PULUMI_TERRAFORM_MODULE_EXECUTOR") || "");
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts, false /*dependency*/, utilities.getPackage());
@@ -46,4 +47,8 @@ export interface ProviderArgs {
      * provider configuration for aws
      */
     aws?: pulumi.Input<{[key: string]: any}>;
+    /**
+     * Sets the executor used to run the module.
+     */
+    executor?: pulumi.Input<string>;
 }

--- a/tests/testdata/aws-vpc/node-views/sdks/vpc/utilities.ts
+++ b/tests/testdata/aws-vpc/node-views/sdks/vpc/utilities.ts
@@ -70,6 +70,7 @@ export function lazyLoad(exports: any, props: string[], loadModule: any) {
     }
 }
 
+/** @internal */
 export async function callAsync<T>(
     tok: string,
     props: pulumi.Inputs,


### PR DESCRIPTION
This PR resolves #329 where language SDKs report runtime errors when there are type mismatches between the output types in the schema and the actual runtime types. 

Previously we have used `string` to be the default but there many output shapes that are not strings so this PR changes the default to be `any`. Users would have to cast the output properties they care about into the appropriate type to use it which is a slight inconvenience but better than erroring out from and getting stuck.

This PR also handles a few cases of `try(...)` expressions used in output values to determine their types. For example expressions of the form:
  - `try(<expr1>, <expr2>, ..., "")` would resolve to a `string` type because the default here is the last expression being a string literal
  - `try(<expr1>, <expr2>, ..., null)` would also resolve to a `string` because I have seen many modules use this pattern for to output optional strings / IDs

```tf
# example from the vpc module
output "vpc_id" {
  description = "The ID of the VPC"
  value       = try(aws_vpc.this[0].id, null)
}

# example from the rds module
output "enhanced_monitoring_iam_role_arn" {
  description = "The Amazon Resource Name (ARN) specifying the monitoring role"
  value       = try(aws_iam_role.enhanced_monitoring[0].arn, null)
}
```
Notes:
 - Regenerated the VPC sdk based on this PR + recent changes to the schema overrides
 - Fixes a small issue when applying type overrides where we emit `any` in the type specification but leave the original spec. Added a test that uses `pulumi package get-schema` to verify the correctness of the schema generated
