### PR TITLE
dependencies: pulumi v3.177.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/pulumi/opentofu v0.0.0-20250318202137-3146daceaf73
 	github.com/pulumi/providertest v0.3.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.108.0
-	github.com/pulumi/pulumi/pkg/v3 v3.176.0
-	github.com/pulumi/pulumi/sdk/v3 v3.176.0
+	github.com/pulumi/pulumi/pkg/v3 v3.177.0
+	github.com/pulumi/pulumi/sdk/v3 v3.177.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.16.2
 	google.golang.org/grpc v1.72.1
@@ -105,7 +105,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
-	github.com/cloudflare/circl v1.3.9 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/cyphar/filepath-securejoin v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
-github.com/cloudflare/circl v1.3.9 h1:QFrlgFYf2Qpi8bSpVPK1HBvWpx16v/1TZivyo7pGuBE=
-github.com/cloudflare/circl v1.3.9/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -803,10 +803,10 @@ github.com/pulumi/providertest v0.3.0 h1:Dv10aoFaNQBDRtK8cRbd2uk9vEhpC/NryN+0y7N
 github.com/pulumi/providertest v0.3.0/go.mod h1:aTxVfdxP/Pe0iPbokjBp99x0XaY4fkZB2CjIS5wysMs=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.108.0 h1:ypXrqGaIe652X51dTlJSVW9JdzNYsns3yKp+6C+KF5w=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.108.0/go.mod h1:OURQCCIz/jBcXs1oUsL38P5SamBGc2HJBCcmva4LJi4=
-github.com/pulumi/pulumi/pkg/v3 v3.176.0 h1:akXBEYuOJt2SzAqTIwqaOV+IjDOAxLG4R6tgUYJuSOA=
-github.com/pulumi/pulumi/pkg/v3 v3.176.0/go.mod h1:WDH86DPa9LEv3etXiDInXtDYH80TzrGlBZKouKOIiRo=
-github.com/pulumi/pulumi/sdk/v3 v3.176.0 h1:CjzJ/59O85O492XRvly61F2frc/YO/LNpt9hytGer+k=
-github.com/pulumi/pulumi/sdk/v3 v3.176.0/go.mod h1:AD2BrIxFG4wdCLCFODrOasXhURwrD/8hHrwBcjzyU9Y=
+github.com/pulumi/pulumi/pkg/v3 v3.177.0 h1:ia1F+KJI5atHRiaoC9J+d5dGVjiVrHsAdHjpkprIivI=
+github.com/pulumi/pulumi/pkg/v3 v3.177.0/go.mod h1:xUW/FZGNemCO+aTqlKoRGbLE1Bq+2uOFbmTW5OD1Hnk=
+github.com/pulumi/pulumi/sdk/v3 v3.177.0 h1:k3CEjq+EJsCGOmAPxjEwNEsAFaRoqQzzlti4aqrrLBA=
+github.com/pulumi/pulumi/sdk/v3 v3.177.0/go.mod h1:AD2BrIxFG4wdCLCFODrOasXhURwrD/8hHrwBcjzyU9Y=
 github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abqkI3OhJ0G04LLI=
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -1039,9 +1039,6 @@ func TestE2eYAML(t *testing.T) {
 				opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath)),
 				// The program references a module that doesn't exist yet, so we skip the install step,
 				opttest.SkipInstall(),
-
-				// TODO[pulumi/pulumi-terraform-module#403] remove the need to set this envvar for YAML programs
-				opttest.Env("PULUMI_ENABLE_VIEWS_PREVIEW", "true"),
 			}
 
 			e2eTest := newPulumiTest(t, testProgram, testOpts...)


### PR DESCRIPTION
Update Pulumi to v3.177.0. This enables YAML programs without having to specify `PULUMI_ENABLE_VIEWS_PREVIEW`.

Fixes #403