### PR TITLE
Emit empty features block for default azurerm provider without configuring one explicitly

### DIFF
--- a/examples/azure-vnet-example/.gitignore
+++ b/examples/azure-vnet-example/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/azure-vnet-example/Pulumi.yaml
+++ b/examples/azure-vnet-example/Pulumi.yaml
@@ -1,0 +1,18 @@
+name: azure-vnet-example
+description: A minimal Azure Native TypeScript Pulumi program
+runtime:
+  name: nodejs
+  options:
+    packagemanager: npm
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: azure-typescript
+packages:
+  vnet:
+    source: terraform-module
+    version: 0.1.6
+    parameters:
+      - Azure/avm-res-network-virtualnetwork/azurerm
+      - 0.8.1
+      - vnet

--- a/examples/azure-vnet-example/README.md
+++ b/examples/azure-vnet-example/README.md
@@ -1,0 +1,85 @@
+ # Azure Native TypeScript Pulumi Template
+
+ This template provides a minimal, ready-to-go Pulumi program for deploying Azure resources using the Azure Native provider in TypeScript. It establishes a basic infrastructure stack that you can use as a foundation for more complex deployments.
+
+ ## When to Use This Template
+
+ - You need a quick boilerplate for Azure Native deployments with Pulumi and TypeScript
+ - You want to create a Resource Group and Storage Account as a starting point
+ - You’re exploring Pulumi’s Azure Native SDK and TypeScript support
+
+ ## Prerequisites
+
+ - An active Azure subscription
+ - Node.js (LTS) installed
+ - A Pulumi account and CLI already installed and configured
+ - Azure credentials available (e.g., via `az login` or environment variables)
+
+ ## Usage
+
+ Scaffold a new project from the Pulumi registry template:
+ ```bash
+ pulumi new azure-typescript
+ ```
+
+ Follow the prompts to:
+ 1. Name your project and stack
+ 2. (Optionally) override the default Azure location
+
+ Once the project is created:
+ ```bash
+ cd <your-project-name>
+ pulumi config set azure-native:location <your-region>
+ pulumi up
+ ```
+
+ ## Project Layout
+
+ ```
+ .
+ ├── Pulumi.yaml       # Project metadata & template configuration
+ ├── index.ts          # Main Pulumi program defining resources
+ ├── package.json      # Node.js dependencies and project metadata
+ └── tsconfig.json     # TypeScript compiler options
+ ```
+
+ ## Configuration
+
+ Pulumi configuration lets you customize deployment parameters.
+
+ - **azure-native:location** (string)
+   - Description: Azure region to provision resources in
+   - Default: `WestUS2`
+
+ Set a custom location before deployment:
+ ```bash
+ pulumi config set azure-native:location eastus
+ ```
+
+ ## Resources Created
+
+ 1. **Resource Group**: A container for all other resources
+ 2. **Storage Account**: A StorageV2 account with Standard_LRS SKU
+
+ ## Outputs
+
+ After `pulumi up`, the following output is exported:
+ - **primaryStorageKey**: The primary access key for the created Storage Account
+
+ Retrieve it with:
+ ```bash
+ pulumi stack output primaryStorageKey
+ ```
+
+ ## Next Steps
+
+ - Extend this template by adding more Azure Native resources (e.g., Networking, App Services)
+ - Modularize your stack with Pulumi Components for reusable architectures
+ - Integrate with CI/CD pipelines (GitHub Actions, Azure DevOps, etc.)
+
+ ## Getting Help
+
+ If you have questions or run into issues:
+ - Explore the Pulumi docs: https://www.pulumi.com/docs/
+ - Join the Pulumi Community on Slack: https://pulumi-community.slack.com/
+ - File an issue on the Pulumi Azure Native SDK GitHub: https://github.com/pulumi/pulumi-azure-native/issues

--- a/examples/azure-vnet-example/index.ts
+++ b/examples/azure-vnet-example/index.ts
@@ -1,0 +1,17 @@
+import * as resources from "@pulumi/azure-native/resources";
+import * as vnet from "@pulumi/vnet";
+
+const resourceGroup = new resources.ResourceGroup("resourceGroup", {
+    location: "EastUS",
+});
+
+// Create a virtual network in the resource group
+// requires ARM_SUBSCRIPTION_ID environment variable to be set
+const virtualNetwork = new vnet.Module("testvnet", {
+    resource_group_name: resourceGroup.name,
+    location: resourceGroup.location,
+    address_space: ["10.0.0.0/16"],
+    name: "testvnet",
+})
+
+export const networkId = virtualNetwork.id;

--- a/examples/azure-vnet-example/package.json
+++ b/examples/azure-vnet-example/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "azure-vnet-example",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/azure-native": "^2.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "@pulumi/vnet": "file:sdks/vnet"
+    }
+}

--- a/examples/azure-vnet-example/tsconfig.json
+++ b/examples/azure-vnet-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -56,6 +57,41 @@ func Test_RdsExample(t *testing.T) {
 
 	// Due to some issues in the RDS resource there is going to be drift even after initial creation, which
 	// will show up as changes planned in the preview. so we refresh first before preview.
+	integrationTest.Preview(t,
+		optpreview.Diff(),
+		optpreview.ExpectNoChanges(),
+		optpreview.ErrorProgressStreams(tw),
+		optpreview.ProgressStreams(tw),
+	)
+}
+
+func Test_Azure_VirtualNetworkExample_NoExplicitProvider(t *testing.T) {
+	t.Parallel()
+
+	if _, ci := os.LookupEnv("CI"); !ci {
+		t.Skip("Skipping Azure tests in local runs without credentials.")
+	}
+
+	if _, ok := os.LookupEnv("ARM_SUBSCRIPTION_ID"); !ok {
+		t.Skip("Skipping AzureRM tests without ARM_SUBSCRIPTION_ID set.")
+	}
+
+	tw := newTestWriter(t)
+	localProviderBinPath := ensureCompiledProvider(t)
+	// Module written to support the test.
+	testProgram, err := filepath.Abs(filepath.Join("../", "examples", "azure-vnet-example"))
+	require.NoError(t, err)
+	localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
+	integrationTest := newPulumiTest(t, testProgram, localPath)
+
+	// Generate package
+	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "Azure/avm-res-network-virtualnetwork/azurerm", "0.8.1", "vnet")
+
+	integrationTest.Up(t, optup.Diff(),
+		optup.ErrorProgressStreams(tw),
+		optup.ProgressStreams(tw),
+	)
+
 	integrationTest.Preview(t,
 		optpreview.Diff(),
 		optpreview.ExpectNoChanges(),

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -85,7 +85,8 @@ func Test_Azure_VirtualNetworkExample_NoExplicitProvider(t *testing.T) {
 	integrationTest := newPulumiTest(t, testProgram, localPath)
 
 	// Generate package
-	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "Azure/avm-res-network-virtualnetwork/azurerm", "0.8.1", "vnet")
+	pulumiPackageAdd(t, integrationTest, localProviderBinPath,
+		"Azure/avm-res-network-virtualnetwork/azurerm", "0.8.1", "vnet")
 
 	integrationTest.Up(t, optup.Diff(),
 		optup.ErrorProgressStreams(tw),


### PR DESCRIPTION
Emit empty features { } block for default azurerm provider when it is not explicitly configured (default provider) because otherwise `azurerm` modules requires explicit providers always. 

Added an integration test that works locally. Not sure if CI exposes `ARM_SUBSCRIPTION_ID` because it is needed for the test to run. 

Note: the module will error out if `ARM_SUBSCRIPTION_ID` is not available but it will say that `subscription_id` is missing from the provider config which can be a bit misleading. 

Fixes #410 