### PR TITLE
bump eks module version to avoid breaking changes due to terrafrom-provider-aws v6.0.0 release

### DIFF
--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -121,7 +121,7 @@ func Test_EksExample(t *testing.T) {
 
 	// Generate package
 	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/vpc/aws", "5.19.0", "vpcmod")
-	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/eks/aws", "20.34.0", "eksmod")
+	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/eks/aws", "20.37.1", "eksmod")
 
 	integrationTest.Up(t, optup.Diff(),
 		optup.ErrorProgressStreams(tw),


### PR DESCRIPTION
Bumped the version of the EKS module used in tests as it was broken by the latest terrafrom-provider-aws release (see [fix: Restrict AWS provider max version due to v6 provider breaking changes · terraform-aws-eks/3384](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3384))