### PR TITLE
WIP: try to bubble up resource replacements to module replacements

### DIFF
--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -188,10 +188,14 @@ func (h *moduleHandler) Diff(
 	println("outputsChanged?", outputsChanged)
 
 	if inputsChanged || resourcesChanged || outputsChanged {
-		return &pulumirpc.DiffResponse{
-			Changes:  pulumirpc.DiffResponse_DIFF_SOME,
-			Replaces: replaceKeys,
-		}, nil
+		resp := &pulumirpc.DiffResponse{
+			Changes: pulumirpc.DiffResponse_DIFF_SOME,
+		}
+		if len(replaceKeys) > 0 {
+			resp.Replaces = replaceKeys
+			resp.DeleteBeforeReplace = true
+		}
+		return resp, nil
 	}
 
 	// the module has not changed, return DIFF_NONE.


### PR DESCRIPTION
Exploring how to lift resource replaces planned by TF into module replacements.

This code currently successfully causes the module to replace, but errors during the update:

```
Do you want to perform this update? yes
Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/mjeffryes-pulumi-corp/tstest/dev/updates/3

     Type                                    Name                                                                                  Status                         I
     pulumi:pulumi:Stack                     tstest-dev                                                                            **failed**                     1
 ~   ├─ sgmod:index:Module                   sg2                                                                                   refresh (12s)
 ~   │  ├─ sgmod:tf:aws_security_group_rule  module.sg2.aws_security_group_rule.computed_ingress_with_source_security_group_id[0]  refresh (4s)
 ~   │  └─ sgmod:tf:aws_security_group       module.sg2.aws_security_group.this_name_prefix[0]                                     refresh (4s)
 +-  └─ sgmod:index:Module                   sg1                                                                                   **replacing failed (10s)**     [
 +      └─ sgmod:tf:aws_security_group       module.sg1.aws_security_group.this_name_prefix[0]                                     created (0.26s)

Diagnostics:
  sgmod:index:Module (sg1):
    error: post-step event returned an error: failed to verify snapshot: duplicate resource urn:pulumi:dev::tstest::sgmod:index:Module$sgmod:tf:aws_security_group::module.sg1.aws_security_group.this_name_prefix[0] (not marked for deletion)

  pulumi:pulumi:Stack (tstest-dev):
    I0619 15:10:56.112321   97893 main.go:393] one or more errors while discovering plugins: 2 errors occurred:
    	* unmarshaling package.json /Volumes/Data/workspace/pulumi/tf_modules_dogfood/tstest/node_modules/resolve/test/resolver/false_main/package.json: json: cannot unmarshal bool into Go struct field packageJSON.main of type string
    	* unmarshaling package.json /Volumes/Data/workspace/pulumi/tf_modules_dogfood/tstest/node_modules/resolve/test/resolver/invalid_main/package.json: json: cannot unmarshal array into Go struct field packageJSON.main of type string
    I0619 15:11:09.562991   97893 log.go:73] Language host launching process: /opt/homebrew/bin/node/Volumes/Data/workspace/pulumi/tf_modules_dogfood/tstest/node_modules/@pulumi/pulumi/cmd/run/index.js --monitor 127.0.0.1:58878 --engine 127.0.0.1:58837 --sync /var/folders/1p/p4yjm1xs3vgbm01c0gbvr5qr0000gn/T/pulumi-node-pipes104983121 --organization mjeffryes-pulumi-corp --project tstest --root-directory /Volumes/Data/workspace/pulumi/tf_modules_dogfood/tstest --stack dev --pwd /Volumes/Data/workspace/pulumi/tf_modules_dogfood/tstest --parallel 48 .
    I0619 15:11:25.671743   97893 ignore.go:44] Explicitly ignoring and discarding error: sync /dev/stdout: bad file descriptor
    I0619 15:11:25.672111   97893 ignore.go:44] Explicitly ignoring and discarding error: sync /dev/stderr: bad file descriptor

    warning: using pulumi-resource-terraform-module from $PATH at /Users/mjeffryes/workspace/pulumi/pulumi-terraform-module/bin/pulumi-resource-terraform-module
    warning: using pulumi-resource-terraform-module from $PATH at /Users/mjeffryes/workspace/pulumi/pulumi-terraform-module/bin/pulumi-resource-terraform-module
    warning: resource plugin terraform-module is expected to have version >=0.1.6, but has 0.0.0-alpha.0+dev; the wrong version may be on your path, or this may be a bug in the plugin
    warning: using pulumi-resource-terraform-module from $PATH at /Users/mjeffryes/workspace/pulumi/pulumi-terraform-module/bin/pulumi-resource-terraform-module
    warning: resource plugin terraform-module is expected to have version >=0.1.6, but has 0.0.0-alpha.0+dev; the wrong version may be on your path, or this may be a bug in the plugin
    error: update failed

    [Pulumi Copilot] Would you like help with these diagnostics?
    https://app.pulumi.com/mjeffryes-pulumi-corp/tstest/dev/updates/3?explainFailure

Resources:
    + 1 created
    1 unchanged

Duration: 30s
```

My best guess is that we failed to indicate to the engine that the resources within the module would also be replaced as a result of the module replacement?