### PR TITLE
Report partial errors on create and update

### DIFF
--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -492,17 +492,20 @@ func (h *moduleHandler) Update(
 		req.GetPreview(),
 		executor,
 	)
-	// TODO[pulumi/pulumi-terraform-module#342] partial error handling needs to modify this.
-	if err != nil {
-		return nil, err
+
+	// Publish views even if applyErr != nil as is the case of partial failures.
+	if views != nil {
+		_, err = statusClient.PublishViewSteps(ctx, &pulumirpc.PublishViewStepsRequest{
+			Token: req.ResourceStatusToken,
+			Steps: views,
+		})
+		if err != nil {
+			logger.Log(ctx, tfsandbox.Debug, fmt.Sprintf("error publishing view steps after Update: %v", err))
+			return nil, err
+		}
 	}
 
-	_, err = statusClient.PublishViewSteps(ctx, &pulumirpc.PublishViewStepsRequest{
-		Token: req.ResourceStatusToken,
-		Steps: views,
-	})
 	if err != nil {
-		logger.Log(ctx, tfsandbox.Debug, fmt.Sprintf("error publishing view steps after Update: %v", err))
 		return nil, err
 	}
 

--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -325,15 +325,8 @@ func (h *moduleHandler) applyModuleOperation(
 	}
 
 	if applyErr != nil {
-		// TODO[pulumi/pulumi-terraform-module#342] Possibly wrap partial errors in initializationError. This
-		// does not quite work as expected yet as views get recorded into state as pending_operations. They
-		// need to be recorded as finalized operations because they did complete.
-		if 1+2 == 4 {
-			applyErr = h.initializationError(moduleOutputs, applyErr.Error())
-		}
-
-		// Instead, log and propagate the error for now. This will forget partial TF state but fail Pulumi.
-		logger.Log(ctx, tfsandbox.Error, fmt.Sprintf("partial failure in apply: %v", applyErr))
+		// we have a partial error, wrap it with ErrorResourceInitFailed
+		applyErr = h.initializationError(moduleOutputs, applyErr.Error())
 	}
 
 	hasOutputFieldMappings := inferredModule != nil &&

--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -479,7 +479,7 @@ func (h *moduleHandler) Update(
 
 	//q.Q("Update", req.GetPreview())
 
-	moduleOutputs, views, err := h.applyModuleOperation(
+	moduleOutputs, views, applyErr := h.applyModuleOperation(
 		ctx,
 		urn,
 		moduleInputs,
@@ -505,8 +505,8 @@ func (h *moduleHandler) Update(
 		}
 	}
 
-	if err != nil {
-		return nil, err
+	if applyErr != nil {
+		return nil, applyErr
 	}
 
 	props, err := plugin.MarshalProperties(moduleOutputs, h.marshalOpts())

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -245,8 +245,6 @@ func TestLambdaMemorySizeDiff(t *testing.T) {
 func TestPartialApply(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("TODO[pulumi/pulumi#19635]")
-
 	var debugOpts debug.LoggingOptions
 
 	// To enable debug logging in this test, un-comment:

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -319,6 +319,8 @@ func TestPartialApply(t *testing.T) {
 	}, changes2)
 	assert.Contains(t, upRes2.Outputs, "roleArn")
 
+	t.Logf("State: %s", string(integrationTest.ExportStack(t).Deployment))
+
 	t.Logf("################################################################################")
 	t.Logf("step 3 - partial failure in update")
 	t.Logf("################################################################################")
@@ -334,6 +336,8 @@ func TestPartialApply(t *testing.T) {
 	)
 
 	assert.Errorf(t, err, "expected error on up")
+
+	t.Logf("State: %s", string(integrationTest.ExportStack(t).Deployment))
 
 	t.Logf("################################################################################")
 	t.Logf("step 4 - complete update")
@@ -354,6 +358,8 @@ func TestPartialApply(t *testing.T) {
 		"same":   1,
 	}, changes4)
 	assert.Contains(t, upRes4.Outputs, "roleArn")
+
+	t.Logf("State: %s", string(integrationTest.ExportStack(t).Deployment))
 }
 
 // Sanity check that we can provision two instances of the same module side-by-side, in particular

--- a/tests/testdata/programs/ts/partial-apply/index.ts
+++ b/tests/testdata/programs/ts/partial-apply/index.ts
@@ -6,9 +6,10 @@ const prefix = config.get('prefix') ?? pulumi.getStack();
 const step = config.getNumber('step') ?? 1;
 
 const mod = new localmod.Module('test-localmod', {
-    name_prefix: prefix,
-    should_fail: step === 1 ? true : false,
+  name_prefix: prefix,
+  description: `Step ${step}`,
+  should_fail: step % 2 === 1 ? true : false,
 });
 
-export const roleArn =  mod.role_arn;
+export const roleArn = mod.role_arn;
 

--- a/tests/testdata/programs/ts/partial-apply/local_module/main.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/main.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "this" {
   name_prefix = var.name_prefix
+  description = var.description
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/tests/testdata/programs/ts/partial-apply/local_module/variables.tf
+++ b/tests/testdata/programs/ts/partial-apply/local_module/variables.tf
@@ -3,6 +3,11 @@ variable "name_prefix" {
   description = "Prefix to use for the name of the IAM role"
 }
 
+variable "description" {
+  type        = string
+  description = "description of the IAM role"
+}
+
 variable "should_fail" {
   type        = bool
   description = "Whether the module should fail"


### PR DESCRIPTION
Following the suggestion in https://github.com/pulumi/pulumi-terraform-module/issues/342#issuecomment-2987099194 to report partial errors. 

Expanded the tests for partial apply to also exercise generate errors during an update. Includes additional fixes from @justinvp's to how `update` reports views and to how we identify failing view steps, particularly for replacements.

fixes: https://github.com/pulumi/pulumi-terraform-module/issues/386
related: https://github.com/pulumi/pulumi/issues/19635, https://github.com/pulumi/pulumi-terraform-module/issues/342 (We may need additional testing on delete and refresh before declaring these issues complete)
