### PR TITLE
Fix emitting warning status logs as visible messages

### DIFF
--- a/pkg/modprovider/logger.go
+++ b/pkg/modprovider/logger.go
@@ -113,7 +113,15 @@ func (l *resourceLogger) Log(ctx context.Context, level tfsandbox.LogLevel, mess
 		return
 	}
 
-	err := l.hc.Log(ctx, asSeverity(level), l.urn, message)
+	diagLevel := asSeverity(level)
+
+	if diagLevel == diag.Error && isMissingCredentialsErrorFromAWS(message) {
+		// for AWS provider, we can detect missing credentials errors and provide a more helpful message
+		// that is specific to Pulumi users.
+		message = awsMissingCredentialsErrorMessage
+	}
+
+	err := l.hc.Log(ctx, diagLevel, l.urn, message)
 	contract.IgnoreError(err)
 }
 


### PR DESCRIPTION
`pulumi package add terraform module ...` used to print "Using Terraform CLI for schema inference" to stdout. This is now fixed. The root cause is that DEBUG level messages were sent at INFO level to the engine on the wire by mistake.