### PR TITLE
Fix staticcheck lint errors (ST1005, QF1008)

### DIFF
--- a/pkg/modprovider/server.go
+++ b/pkg/modprovider/server.go
@@ -436,7 +436,7 @@ func (s *server) CheckConfig(
 	// Temporarily duplicate the Handshake check because old Pulumi CLI versions ignored Handshake errors.
 	if !s.pulumiCliSupportsViews {
 		return nil, errors.New("terraform-module provider requires a Pulumi CLI with resource " +
-			"views support. Please update Pulumi CLI to the latest version.")
+			"views support. Please update Pulumi CLI to the latest version")
 	}
 
 	s.providerSelfURN = pulumi.URN(req.Urn)
@@ -509,7 +509,7 @@ func (s *server) Handshake(
 	if !req.SupportsViews {
 		s.pulumiCliSupportsViews = false
 		return nil, errors.New("terraform-module provider requires a Pulumi CLI with resource " +
-			"views support. Please update Pulumi CLI to the latest version.")
+			"views support. Please update Pulumi CLI to the latest version")
 	}
 	s.pulumiCliSupportsViews = true
 	return &pulumirpc.ProviderHandshakeResponse{

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -555,18 +555,18 @@ func combineInferredModuleSchema(
 			existingInput.Secret = input.Secret
 		}
 
-		if input.TypeSpec.Type != "" {
-			existingInput.TypeSpec.Type = input.TypeSpec.Type
+		if input.Type != "" {
+			existingInput.Type = input.Type
 		}
 
-		if input.TypeSpec.Items != nil {
-			existingInput.TypeSpec.Items = input.TypeSpec.Items
-			existingInput.TypeSpec.AdditionalProperties = nil
+		if input.Items != nil {
+			existingInput.Items = input.Items
+			existingInput.AdditionalProperties = nil
 		}
 
-		if input.TypeSpec.AdditionalProperties != nil {
-			existingInput.TypeSpec.AdditionalProperties = input.TypeSpec.AdditionalProperties
-			existingInput.TypeSpec.Items = nil
+		if input.AdditionalProperties != nil {
+			existingInput.AdditionalProperties = input.AdditionalProperties
+			existingInput.Items = nil
 		}
 	}
 
@@ -621,11 +621,6 @@ func combineInferredModuleSchema(
 		if typeSpec.Type != "" {
 			existingType.Type = typeSpec.Type
 		}
-
-		if typeSpec.ObjectTypeSpec.Type != "" {
-			existingType.ObjectTypeSpec.Type = typeSpec.ObjectTypeSpec.Type
-		}
-
 	}
 
 	return inferredSchema


### PR DESCRIPTION
## Summary

Fixes staticcheck lint errors surfaced after the golangci-lint v2 template rollout from pulumi/ci-mgmt#2130.

- **ST1005** (`server.go`): Error strings should not end with punctuation — removed trailing `.` from two `errors.New(...)` calls in `CheckConfig` and `Handshake`.

- **QF1008** (`tfmodules.go`): Remove redundant embedded field selectors in `combineInferredModuleSchema`:
  - `input.TypeSpec.Type/Items/AdditionalProperties` → `input.Type/Items/AdditionalProperties` (TypeSpec is embedded in PropertySpec)
  - `typeSpec.ObjectTypeSpec.Type` → `typeSpec.Type` (ObjectTypeSpec is embedded in ComplexTypeSpec). This also removes a duplicate assignment that was previously hidden behind the different selector name.

Part of #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)