### PR TITLE
Fix remaining QF1008 staticcheck errors in outputs merge loop

### DIFF
--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -588,23 +588,23 @@ func combineInferredModuleSchema(
 
 		if output.Ref != "" {
 			existingOutput.Ref = output.Ref
-			existingOutput.TypeSpec.AdditionalProperties = nil
-			existingOutput.TypeSpec.Items = nil
-			existingOutput.TypeSpec.Type = ""
+			existingOutput.AdditionalProperties = nil
+			existingOutput.Items = nil
+			existingOutput.Type = ""
 		}
-		if output.TypeSpec.Type != "" {
-			existingOutput.TypeSpec.Type = output.TypeSpec.Type
-			existingOutput.TypeSpec.Ref = ""
+		if output.Type != "" {
+			existingOutput.Type = output.Type
+			existingOutput.Ref = ""
 		}
-		if output.TypeSpec.Items != nil {
-			existingOutput.TypeSpec.Items = output.TypeSpec.Items
-			existingOutput.TypeSpec.AdditionalProperties = nil
-			existingOutput.TypeSpec.Ref = ""
+		if output.Items != nil {
+			existingOutput.Items = output.Items
+			existingOutput.AdditionalProperties = nil
+			existingOutput.Ref = ""
 		}
-		if output.TypeSpec.AdditionalProperties != nil {
-			existingOutput.TypeSpec.AdditionalProperties = output.TypeSpec.AdditionalProperties
-			existingOutput.TypeSpec.Items = nil
-			existingOutput.TypeSpec.Ref = ""
+		if output.AdditionalProperties != nil {
+			existingOutput.AdditionalProperties = output.AdditionalProperties
+			existingOutput.Items = nil
+			existingOutput.Ref = ""
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #795 — fixes additional QF1008 staticcheck errors in `combineInferredModuleSchema` that were discovered when the golangci-lint v2 rollout PR (#798) ran against the new config.

The outputs merge loop had the same `TypeSpec.` embedded field selector pattern as the inputs loop fixed in #795. All occurrences removed:
- `existingOutput.TypeSpec.{Type,Items,AdditionalProperties,Ref}` → `existingOutput.{Type,Items,AdditionalProperties,Ref}`
- `output.TypeSpec.{Type,Items,AdditionalProperties}` → `output.{Type,Items,AdditionalProperties}`

Closes the remaining lint failures blocking pulumi/pulumi-terraform-module#798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)