### PR TITLE
Fix QF1008 staticcheck error in tfmodules_test.go

### DIFF
--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -296,7 +296,7 @@ func TestApplyModuleOverrides(t *testing.T) {
 				vpcID := overridenSchema.Outputs["vpc_id"]
 				assert.Equal(t, "The new ID field of the VPC", vpcID.Description, "vpc_id description should be updated")
 				assert.True(t, vpcID.Secret, "vpc_id should be secret")
-				assert.Equal(t, "string", vpcID.TypeSpec.Type, "vpc_id type should not be changed")
+				assert.Equal(t, "string", vpcID.Type, "vpc_id type should not be changed")
 				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey("vpc_id"), "vpc_id should be non-nil")
 			})
 		})


### PR DESCRIPTION
Fix QF1008 staticcheck error in `tfmodules_test.go`.

`PropertySpec` embeds `TypeSpec`, so `vpcID.TypeSpec.Type` can be simplified to `vpcID.Type`.

Part of pulumi/pulumi-terraform-module#811
