### PR TITLE
modprovider: fix embedded schema override paths

### DIFF
--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -64,7 +65,7 @@ func parseModuleSchemaOverrides(packageName string) []*ModuleSchemaOverride {
 			continue
 		}
 
-		data, err := moduleSchemaOverrides.ReadFile(filepath.Join(dir, file.Name()))
+		data, err := moduleSchemaOverrides.ReadFile(path.Join(dir, file.Name()))
 		if err != nil {
 			panic(fmt.Sprintf("failed to read module schema overrides file %s: %v", file.Name(), err))
 		}


### PR DESCRIPTION
These changes fix path construction in parseModuleSchemaOverrides. This
function enumerates embedded schema overrides stored as JSON files in an
embed.FS, reading and parsing each in turn. In order to read and parse
an override file, the function needs to open it, which reuqires
constructing its path. This path construction was improperly using
filepath.Join: paths in fs.FS values are always '/' separated, even on
Windows.

Fixes #830.
