### PR TITLE
auxprovider: ignore ErrServerStopped on Close

### DIFF
--- a/pkg/auxprovider/server.go
+++ b/pkg/auxprovider/server.go
@@ -15,6 +15,7 @@
 package auxprovider
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -33,7 +34,12 @@ type Server struct {
 
 func (srv *Server) Close() error {
 	srv.server.GracefulStop()
-	return <-srv.serveError
+	// Serve returns ErrServerStopped if GracefulStop ran before the serving
+	// goroutine entered Serve. The server is stopped either way.
+	if err := <-srv.serveError; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+		return err
+	}
+	return nil
 }
 
 func Serve() (*Server, error) {


### PR DESCRIPTION
These changes update `Server.Close` to tolerate `grpc.ErrServerStopped` from the serving goroutine. If `Close` is called before that goroutine has entered `s.Serve`, `GracefulStop` sets `s.lis` to nil first and `Serve` then returns `ErrServerStopped`. The server is stopped either way, so `Close` can treat that as a benign outcome.

This race surfaces in `TestPickModuleRuntime`, whose body is short enough that the serving goroutine sometimes has not been scheduled by the time cleanup runs `Close`. Previously reported in #817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)