### PR TITLE
tfsandbox: fix panic on partially-unknown module outputs (#839)

### DIFF
--- a/pkg/tfsandbox/details.go
+++ b/pkg/tfsandbox/details.go
@@ -206,17 +206,38 @@ func NewPlan(rawPlan *tfjson.Plan) (*Plan, error) {
 	return p, nil
 }
 
+// isAfterUnknown reports whether a tfjson AfterUnknown value indicates the
+// output is fully or partially unknown. Terraform encodes a fully-unknown value
+// as the bool true, a fully-known value as false (or nil), and a partially
+// unknown value as a structured map/slice mirroring the value's shape. Any
+// non-bool shape means at least one element is unknown, so we treat it as
+// unknown for the purposes of plan-time secret detection.
+func isAfterUnknown(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return x
+	default:
+		return true
+	}
+}
+
 // outputIsSecret returns true if the output is a secret based on the value of the
 // corresponding is_secret output.
 func (p *Plan) outputIsSecret(outputName string) bool {
 	isSecretKey := fmt.Sprintf("%s%s", terraformIsSecretOutputPrefix, outputName)
 	if isSecretVal, ok := p.rawPlan.OutputChanges[isSecretKey]; ok {
-		// If the value is unknown, just return false because we don't know the value
-		// so secretness doesn't matter yet
-		if afterUnknown, ok := isSecretVal.AfterUnknown.(bool); ok && afterUnknown {
+		// If the value is unknown (in whole or in part), return false: we
+		// don't know the secretness yet, and After is typically nil in that
+		// case so a blind type assertion would panic.
+		if isAfterUnknown(isSecretVal.AfterUnknown) {
 			return false
 		}
-		return isSecretVal.After.(bool)
+		if b, ok := isSecretVal.After.(bool); ok {
+			return b
+		}
+		return false
 	}
 	contract.Failf("isSecret key %q not found in output changes", isSecretKey)
 	return false
@@ -230,7 +251,7 @@ func (p *Plan) Outputs() resource.PropertyMap {
 			continue
 		}
 		key := PulumiTopLevelKey(outputKey)
-		if afterUnknown, ok := output.AfterUnknown.(bool); ok && afterUnknown {
+		if isAfterUnknown(output.AfterUnknown) {
 			outputs[key] = unknown()
 		} else {
 			val := resource.NewPropertyValueRepl(output.After, nil, replaceJSONNumberValue)
@@ -289,7 +310,10 @@ func (s *State) FindResourceState(addr ResourceAddress) (*ResourceState, bool) {
 func (s *State) outputIsSecret(outputName string) bool {
 	isSecretKey := fmt.Sprintf("%s%s", terraformIsSecretOutputPrefix, outputName)
 	if isSecretVal, ok := s.rawState.Values.Outputs[isSecretKey]; ok {
-		return isSecretVal.Value.(bool)
+		if b, ok := isSecretVal.Value.(bool); ok {
+			return b
+		}
+		return false
 	}
 	contract.Failf("isSecret key %q not found in output changes", isSecretKey)
 	return false

--- a/pkg/tfsandbox/details_test.go
+++ b/pkg/tfsandbox/details_test.go
@@ -693,3 +693,81 @@ func Test_DeletePlan(t *testing.T) {
 		}
 	})
 }
+
+// Regression test for https://github.com/pulumi/pulumi-terraform-module/issues/839
+//
+// When a module output references an attribute of a resource scheduled for
+// replacement, the output becomes unknown at plan time. Terraform reports
+// partial unknowns in AfterUnknown as a structured map/slice rather than a
+// plain bool, and the companion internal_output_is_secret_* output that the
+// SDK injects inherits that shape. Previously, Plan.outputIsSecret would
+// fall through to a blind After.(bool) type assertion, which panics when
+// After is nil. Both Plan.Outputs and Plan.outputIsSecret should now treat
+// any non-bool AfterUnknown as unknown without panicking.
+func Test_Plan_Outputs_PartialUnknown(t *testing.T) {
+	rawPlan := &tfjson.Plan{
+		PlannedValues: &tfjson.StateValues{RootModule: &tfjson.StateModule{}},
+		OutputChanges: map[string]*tfjson.Change{
+			"fqdn": {
+				After:        nil,
+				AfterUnknown: map[string]interface{}{"host": true},
+			},
+			terraformIsSecretOutputPrefix + "fqdn": {
+				After:        nil,
+				AfterUnknown: map[string]interface{}{"host": true},
+			},
+		},
+	}
+
+	p, err := NewPlan(rawPlan)
+	require.NoError(t, err)
+
+	var outputs resource.PropertyMap
+	require.NotPanics(t, func() {
+		outputs = p.Outputs()
+	})
+
+	val, ok := outputs["fqdn"]
+	require.True(t, ok)
+	assert.True(t, val.IsComputed(), "expected fqdn to be unknown/computed, got %v", val)
+}
+
+// Defense-in-depth: a non-bool After value on the is_secret companion should
+// not panic either.
+func Test_Plan_outputIsSecret_NonBoolAfter(t *testing.T) {
+	rawPlan := &tfjson.Plan{
+		PlannedValues: &tfjson.StateValues{RootModule: &tfjson.StateModule{}},
+		OutputChanges: map[string]*tfjson.Change{
+			terraformIsSecretOutputPrefix + "weird": {
+				After:        "not-a-bool",
+				AfterUnknown: false,
+			},
+		},
+	}
+	p, err := NewPlan(rawPlan)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		assert.False(t, p.outputIsSecret("weird"))
+	})
+}
+
+// Defense-in-depth: a non-bool Value on the is_secret companion in state
+// should not panic.
+func Test_State_outputIsSecret_NonBoolValue(t *testing.T) {
+	rawState := &tfjson.State{
+		Values: &tfjson.StateValues{
+			Outputs: map[string]*tfjson.StateOutput{
+				terraformIsSecretOutputPrefix + "weird": {
+					Value: "not-a-bool",
+				},
+			},
+		},
+	}
+	s, err := NewState(rawState)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		assert.False(t, s.outputIsSecret("weird"))
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes #839: `panic: interface conversion: interface {} is nil, not bool` in `Plan.outputIsSecret` when a module output references an attribute of a resource scheduled for replacement.
- Terraform encodes partial unknowns in `AfterUnknown` as a structured map/slice rather than a plain `bool`. The injected `internal_output_is_secret_*` companion inherits that shape with a `nil` `After`, so the previous blind `After.(bool)` assertion panicked.
- Introduces `isAfterUnknown` (any non-bool shape ⇒ unknown), uses comma-ok on the `After`/`Value` bool assertions in `Plan` and `State` `outputIsSecret`, and marks partially-unknown outputs as unknown in `Plan.Outputs` rather than emitting a `nil` value.

## Test plan

- [x] `go test ./pkg/tfsandbox/` passes.
- [x] `golangci-lint run ./pkg/tfsandbox/...` clean.
- [x] Three regression tests added in `details_test.go`; verified they panic against the unpatched `details.go` and pass against the fix.
  - `Test_Plan_Outputs_PartialUnknown` — exact #839 shape (`AfterUnknown` is a map, `After` is `nil`); asserts the output is marked unknown without panicking.
  - `Test_Plan_outputIsSecret_NonBoolAfter` — defensive coverage for a non-bool `After`.
  - `Test_State_outputIsSecret_NonBoolValue` — defensive coverage for non-bool state `Value`.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)