### PR TITLE
Authenticate to the Pulumi Cloud module registry via the engine-provided token

### DIFF
--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -280,7 +280,7 @@ func (h *moduleHandler) prepSandbox(
 		}
 	}
 
-	injectRegistryToken()
+	injectRegistryToken(ctx, logger)
 	// If the module version changed between deployments, rerun init with -upgrade so the lockfile
 	// is refreshed to match the newer constraint set.
 	if needsInitUpgrade(oldOutputs, previousVersion, moduleVersion) {

--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -280,6 +280,7 @@ func (h *moduleHandler) prepSandbox(
 		}
 	}
 
+	injectRegistryToken()
 	// If the module version changed between deployments, rerun init with -upgrade so the lockfile
 	// is refreshed to match the newer constraint set.
 	if needsInitUpgrade(oldOutputs, previousVersion, moduleVersion) {

--- a/pkg/modprovider/registry_token.go
+++ b/pkg/modprovider/registry_token.go
@@ -15,6 +15,9 @@
 package modprovider
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -23,67 +26,79 @@ import (
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
+
+	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
-// cloudRegistry is the Pulumi Cloud module registry the provider was launched against, plus the
-// access token to authenticate to it. Both come from discovery against the engine-provided backend
-// address: there is no other source of the registry host.
+var errNoModuleRegistry = errors.New("backend does not host a Pulumi Cloud module registry")
+
 type cloudRegistry struct {
 	host  svchost.Hostname
 	token string
 }
 
 var (
-	cloudRegistryOnce sync.Once
-	resolvedRegistry  *cloudRegistry
+	cloudRegistryOnce   sync.Once
+	resolvedRegistry    *cloudRegistry
+	resolvedRegistryErr error
 )
 
-// pulumiCloudRegistry discovers the cloud's Terraform module registry host from the backend address
-// (GET <PULUMI_API>/.well-known/terraform.json, the tfe.v2 service) and pairs it with the access
-// token. It returns nil when the provider was not launched by a logged-in Pulumi Cloud session, and
-// caches the result for the life of the process.
-func pulumiCloudRegistry() *cloudRegistry {
+// pulumiCloudRegistry returns (nil, nil) when the provider was not launched by a logged-in Pulumi
+// Cloud session, caching the first discovery for the life of the process.
+func pulumiCloudRegistry() (*cloudRegistry, error) {
 	cloudRegistryOnce.Do(func() {
-		resolvedRegistry = discoverCloudRegistry(os.Getenv("PULUMI_API"), os.Getenv("PULUMI_ACCESS_TOKEN"))
+		resolvedRegistry, resolvedRegistryErr = discoverCloudRegistry(
+			os.Getenv("PULUMI_API"), os.Getenv("PULUMI_ACCESS_TOKEN"))
 	})
-	return resolvedRegistry
+	return resolvedRegistry, resolvedRegistryErr
 }
 
-func discoverCloudRegistry(apiAddress, token string) *cloudRegistry {
+func discoverCloudRegistry(apiAddress, token string) (*cloudRegistry, error) {
 	return discoverCloudRegistryWith(disco.New(), apiAddress, token)
 }
 
-func discoverCloudRegistryWith(d *disco.Disco, apiAddress, token string) *cloudRegistry {
+func discoverCloudRegistryWith(d *disco.Disco, apiAddress, token string) (*cloudRegistry, error) {
 	if apiAddress == "" || token == "" {
-		return nil
+		return nil, nil
 	}
 	apiURL, err := url.Parse(apiAddress)
-	if err != nil || apiURL.Host == "" {
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("parsing backend address %q: %w", apiAddress, err)
+	}
+	if apiURL.Host == "" {
+		return nil, fmt.Errorf("backend address %q has no host", apiAddress)
 	}
 	apiHost, err := svchost.ForComparison(apiURL.Host)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("normalizing backend host %q: %w", apiURL.Host, err)
 	}
 	serviceURL, err := d.DiscoverServiceURL(apiHost, "tfe.v2")
-	if err != nil || serviceURL == nil {
-		return nil
+	if err != nil {
+		var notProvided *disco.ErrServiceNotProvided
+		if errors.As(err, &notProvided) {
+			return nil, errNoModuleRegistry
+		}
+		return nil, fmt.Errorf("discovering module registry for %q: %w", apiHost, err)
+	}
+	if serviceURL == nil {
+		return nil, errNoModuleRegistry
 	}
 	registryHost, err := svchost.ForComparison(serviceURL.Host)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("normalizing registry host %q: %w", serviceURL.Host, err)
 	}
-	return &cloudRegistry{host: registryHost, token: token}
+	return &cloudRegistry{host: registryHost, token: token}, nil
 }
 
 // injectRegistryToken lets `tofu init` authenticate to the Pulumi Cloud module registry without a
-// separate `terraform login`, by setting TF_TOKEN_<host> for the discovered registry host from the
-// engine-provided access token. tofu sends a TF_TOKEN credential only to its host, so setting it for
-// the one discovered host keeps the token off any other registry. Owning this in the provider keeps
-// Terraform's TF_TOKEN convention out of the Pulumi CLI and covers every entry point that runs tofu
-// (package add, gen-sdk, and runtime).
-func injectRegistryToken() {
-	reg := pulumiCloudRegistry()
+// separate `terraform login`.
+func injectRegistryToken(ctx context.Context, logger tfsandbox.Logger) {
+	reg, err := pulumiCloudRegistry()
+	if err != nil {
+		logger.Log(ctx, tfsandbox.Warn,
+			fmt.Sprintf("could not authenticate to the Pulumi Cloud module registry: %v", err))
+		return
+	}
 	if reg == nil {
 		return
 	}
@@ -93,11 +108,11 @@ func injectRegistryToken() {
 	}
 }
 
-// cloudRegistryCredentials authenticates the module registry client used for unpinned version
-// lookups to the discovered registry host. Like TF_TOKEN, it is scoped to that host: ForHost returns
-// nothing for any other registry.
 func cloudRegistryCredentials() auth.CredentialsSource {
-	return credentialsForRegistry(pulumiCloudRegistry())
+	// A discovery failure surfaces to the user as an error from the subsequent registry request, so
+	// this loggerless path leaves the client unauthenticated rather than handling the error here.
+	reg, _ := pulumiCloudRegistry()
+	return credentialsForRegistry(reg)
 }
 
 func credentialsForRegistry(reg *cloudRegistry) auth.CredentialsSource {
@@ -109,8 +124,7 @@ func credentialsForRegistry(reg *cloudRegistry) auth.CredentialsSource {
 	})
 }
 
-// tfTokenEnvKey encodes the TF_TOKEN_<host> variable name for a host per HashiCorp's convention:
-// dots become single underscores, dashes double underscores.
+// tfTokenEnvKey builds the TF_TOKEN_<host> variable name using OpenTofu's host-encoding convention.
 func tfTokenEnvKey(host svchost.Hostname) string {
 	key := strings.ReplaceAll(string(host), "-", "__")
 	key = strings.ReplaceAll(key, ".", "_")

--- a/pkg/modprovider/registry_token.go
+++ b/pkg/modprovider/registry_token.go
@@ -1,0 +1,118 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modprovider
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	"github.com/hashicorp/terraform-svchost/auth"
+	"github.com/hashicorp/terraform-svchost/disco"
+)
+
+// cloudRegistry is the Pulumi Cloud module registry the provider was launched against, plus the
+// access token to authenticate to it. Both come from discovery against the engine-provided backend
+// address: there is no other source of the registry host.
+type cloudRegistry struct {
+	host  svchost.Hostname
+	token string
+}
+
+var (
+	cloudRegistryOnce sync.Once
+	resolvedRegistry  *cloudRegistry
+)
+
+// pulumiCloudRegistry discovers the cloud's Terraform module registry host from the backend address
+// (GET <PULUMI_API>/.well-known/terraform.json, the tfe.v2 service) and pairs it with the access
+// token. It returns nil when the provider was not launched by a logged-in Pulumi Cloud session, and
+// caches the result for the life of the process.
+func pulumiCloudRegistry() *cloudRegistry {
+	cloudRegistryOnce.Do(func() {
+		resolvedRegistry = discoverCloudRegistry(os.Getenv("PULUMI_API"), os.Getenv("PULUMI_ACCESS_TOKEN"))
+	})
+	return resolvedRegistry
+}
+
+func discoverCloudRegistry(apiAddress, token string) *cloudRegistry {
+	return discoverCloudRegistryWith(disco.New(), apiAddress, token)
+}
+
+func discoverCloudRegistryWith(d *disco.Disco, apiAddress, token string) *cloudRegistry {
+	if apiAddress == "" || token == "" {
+		return nil
+	}
+	apiURL, err := url.Parse(apiAddress)
+	if err != nil || apiURL.Host == "" {
+		return nil
+	}
+	apiHost, err := svchost.ForComparison(apiURL.Host)
+	if err != nil {
+		return nil
+	}
+	serviceURL, err := d.DiscoverServiceURL(apiHost, "tfe.v2")
+	if err != nil || serviceURL == nil {
+		return nil
+	}
+	registryHost, err := svchost.ForComparison(serviceURL.Host)
+	if err != nil {
+		return nil
+	}
+	return &cloudRegistry{host: registryHost, token: token}
+}
+
+// injectRegistryToken lets `tofu init` authenticate to the Pulumi Cloud module registry without a
+// separate `terraform login`, by setting TF_TOKEN_<host> for the discovered registry host from the
+// engine-provided access token. tofu sends a TF_TOKEN credential only to its host, so setting it for
+// the one discovered host keeps the token off any other registry. Owning this in the provider keeps
+// Terraform's TF_TOKEN convention out of the Pulumi CLI and covers every entry point that runs tofu
+// (package add, gen-sdk, and runtime).
+func injectRegistryToken() {
+	reg := pulumiCloudRegistry()
+	if reg == nil {
+		return
+	}
+	key := tfTokenEnvKey(reg.host)
+	if os.Getenv(key) == "" {
+		_ = os.Setenv(key, reg.token)
+	}
+}
+
+// cloudRegistryCredentials authenticates the module registry client used for unpinned version
+// lookups to the discovered registry host. Like TF_TOKEN, it is scoped to that host: ForHost returns
+// nothing for any other registry.
+func cloudRegistryCredentials() auth.CredentialsSource {
+	return credentialsForRegistry(pulumiCloudRegistry())
+}
+
+func credentialsForRegistry(reg *cloudRegistry) auth.CredentialsSource {
+	if reg == nil {
+		return nil
+	}
+	return auth.StaticCredentialsSource(map[svchost.Hostname]map[string]interface{}{
+		reg.host: {"token": reg.token},
+	})
+}
+
+// tfTokenEnvKey encodes the TF_TOKEN_<host> variable name for a host per HashiCorp's convention:
+// dots become single underscores, dashes double underscores.
+func tfTokenEnvKey(host svchost.Hostname) string {
+	key := strings.ReplaceAll(string(host), "-", "__")
+	key = strings.ReplaceAll(key, ".", "_")
+	return "TF_TOKEN_" + key
+}

--- a/pkg/modprovider/registry_token_test.go
+++ b/pkg/modprovider/registry_token_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modprovider
+
+import (
+	"testing"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discoFor returns a discovery client that resolves apiHost to a tfe.v2 service on tfeHost, the way
+// the real Pulumi Cloud backend's discovery document does.
+func discoFor(apiHost, tfeHost string) *disco.Disco {
+	d := disco.New()
+	d.ForceHostServices(svchost.Hostname(apiHost), map[string]interface{}{
+		"tfe.v2": "https://" + tfeHost + "/api/v2",
+	})
+	return d
+}
+
+func TestDiscoverCloudRegistry(t *testing.T) {
+	t.Parallel()
+
+	// The host the engine passes as PULUMI_API differs from the registry host discovery resolves to,
+	// and is dash-heavy, like a review stack. The registry host comes only from discovery.
+	const (
+		apiHost = "api-fnune-review.review-stacks.pulumi-dev.io"
+		tfeHost = "tfe-fnune-review.review-stacks.pulumi-dev.io"
+	)
+	d := discoFor(apiHost, tfeHost)
+	want, err := svchost.ForComparison(tfeHost)
+	require.NoError(t, err)
+
+	t.Run("logged in", func(t *testing.T) {
+		t.Parallel()
+		reg := discoverCloudRegistryWith(d, "https://"+apiHost, "the-token")
+		require.NotNil(t, reg)
+		assert.Equal(t, want, reg.host)
+		assert.Equal(t, "the-token", reg.token)
+	})
+
+	t.Run("no token", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, discoverCloudRegistryWith(d, "https://"+apiHost, ""))
+	})
+
+	t.Run("no backend address", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, discoverCloudRegistryWith(d, "", "the-token"))
+	})
+
+	t.Run("backend without module registry", func(t *testing.T) {
+		t.Parallel()
+		bare := disco.New()
+		bare.ForceHostServices(svchost.Hostname("diy.example.com"), map[string]interface{}{})
+		assert.Nil(t, discoverCloudRegistryWith(bare, "https://diy.example.com", "the-token"))
+	})
+}
+
+func TestTFTokenEnvKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "TF_TOKEN_tfe_pulumi_com", tfTokenEnvKey(svchost.Hostname("tfe.pulumi.com")))
+	assert.Equal(t,
+		"TF_TOKEN_tfe__fnune__review_review__stacks_pulumi__dev_io",
+		tfTokenEnvKey(svchost.Hostname("tfe-fnune-review.review-stacks.pulumi-dev.io")))
+}
+
+func TestCredentialsForRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := &cloudRegistry{host: svchost.Hostname("tfe.pulumi.com"), token: "the-token"}
+	creds := credentialsForRegistry(reg)
+	require.NotNil(t, creds)
+
+	t.Run("registry host gets the token", func(t *testing.T) {
+		t.Parallel()
+		hc, err := creds.ForHost(reg.host)
+		require.NoError(t, err)
+		require.NotNil(t, hc)
+		assert.Equal(t, "the-token", hc.Token())
+	})
+
+	t.Run("third-party host gets nothing", func(t *testing.T) {
+		t.Parallel()
+		hc, err := creds.ForHost(svchost.Hostname("registry.terraform.io"))
+		require.NoError(t, err)
+		assert.Nil(t, hc)
+	})
+
+	t.Run("no registry yields no credentials", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, credentialsForRegistry(nil))
+	})
+}

--- a/pkg/modprovider/registry_token_test.go
+++ b/pkg/modprovider/registry_token_test.go
@@ -23,9 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// discoFor returns a discovery client that resolves apiHost to a tfe.v2 service on tfeHost, the way
-// the real Pulumi Cloud backend's discovery document does.
-func discoFor(apiHost, tfeHost string) *disco.Disco {
+func discoveryFor(apiHost, tfeHost string) *disco.Disco {
 	d := disco.New()
 	d.ForceHostServices(svchost.Hostname(apiHost), map[string]interface{}{
 		"tfe.v2": "https://" + tfeHost + "/api/v2",
@@ -42,33 +40,47 @@ func TestDiscoverCloudRegistry(t *testing.T) {
 		apiHost = "api-fnune-review.review-stacks.pulumi-dev.io"
 		tfeHost = "tfe-fnune-review.review-stacks.pulumi-dev.io"
 	)
-	d := discoFor(apiHost, tfeHost)
+	d := discoveryFor(apiHost, tfeHost)
 	want, err := svchost.ForComparison(tfeHost)
 	require.NoError(t, err)
 
 	t.Run("logged in", func(t *testing.T) {
 		t.Parallel()
-		reg := discoverCloudRegistryWith(d, "https://"+apiHost, "the-token")
+		reg, err := discoverCloudRegistryWith(d, "https://"+apiHost, "the-token")
+		require.NoError(t, err)
 		require.NotNil(t, reg)
 		assert.Equal(t, want, reg.host)
 		assert.Equal(t, "the-token", reg.token)
 	})
 
-	t.Run("no token", func(t *testing.T) {
+	t.Run("no token means not logged in, not an error", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, discoverCloudRegistryWith(d, "https://"+apiHost, ""))
+		reg, err := discoverCloudRegistryWith(d, "https://"+apiHost, "")
+		require.NoError(t, err)
+		assert.Nil(t, reg)
 	})
 
-	t.Run("no backend address", func(t *testing.T) {
+	t.Run("no backend address means not logged in, not an error", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, discoverCloudRegistryWith(d, "", "the-token"))
+		reg, err := discoverCloudRegistryWith(d, "", "the-token")
+		require.NoError(t, err)
+		assert.Nil(t, reg)
 	})
 
-	t.Run("backend without module registry", func(t *testing.T) {
+	t.Run("malformed backend address errors", func(t *testing.T) {
+		t.Parallel()
+		reg, err := discoverCloudRegistryWith(d, "https://", "the-token")
+		assert.Nil(t, reg)
+		require.ErrorContains(t, err, "has no host")
+	})
+
+	t.Run("backend without module registry errors", func(t *testing.T) {
 		t.Parallel()
 		bare := disco.New()
 		bare.ForceHostServices(svchost.Hostname("diy.example.com"), map[string]interface{}{})
-		assert.Nil(t, discoverCloudRegistryWith(bare, "https://diy.example.com", "the-token"))
+		reg, err := discoverCloudRegistryWith(bare, "https://diy.example.com", "the-token")
+		assert.Nil(t, reg)
+		require.ErrorIs(t, err, errNoModuleRegistry)
 	})
 }
 

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -719,7 +719,7 @@ func resolveModuleSources(
 	}
 
 	// init will resolve module sources and create .terraform/modules folder
-	injectRegistryToken()
+	injectRegistryToken(ctx, logger)
 	if err := tf.Init(ctx, logger); err != nil {
 		return "", fmt.Errorf("init failure (%s): %w", tf.Description(), err)
 	}

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -312,7 +312,7 @@ func latestModuleVersion(ctx context.Context, moduleSource string) (*version.Ver
 		return nil, fmt.Errorf("module source for %s is not from a remote registry", moduleSource)
 	}
 
-	services := disco.NewWithCredentialsSource(nil)
+	services := disco.NewWithCredentialsSource(cloudRegistryCredentials())
 	reg := registry.NewClient(services, nil)
 	regsrcAddr := regsrc.ModuleFromRegistryPackageAddr(source.Package)
 	resp, err := reg.ModuleVersions(ctx, regsrcAddr)
@@ -719,6 +719,7 @@ func resolveModuleSources(
 	}
 
 	// init will resolve module sources and create .terraform/modules folder
+	injectRegistryToken()
 	if err := tf.Init(ctx, logger); err != nil {
 		return "", fmt.Errorf("init failure (%s): %w", tf.Description(), err)
 	}


### PR DESCRIPTION
Authenticate to the Pulumi Cloud module registry using credentials the engine
provides, so consuming a private Terraform module from the Cloud registry needs
no separate `terraform login`.

## How

When the engine launches this provider it now passes `PULUMI_API` and
`PULUMI_ACCESS_TOKEN` (see pulumi/pulumi#23589). The provider:

1. Reads the API address from `PULUMI_API`.
2. Resolves that backend's service-discovery document (`.well-known/terraform.json`)
   to find the registry host — the registry lives on a different host from the
   API, so the host is discovered, never assumed.
3. Sets `TF_TOKEN_<registry-host>` from `PULUMI_ACCESS_TOKEN`, scoped to the
   discovered host, so the embedded OpenTofu authenticates to the registry.

If the credentials are absent (no cloud login), nothing is injected and behavior
is unchanged.

### Why the provider owns this

tofu sends a `TF_TOKEN` credential only to its matching host, so setting it for
the one discovered registry host keeps the token off any other registry. Owning
this in the provider keeps Terraform's `TF_TOKEN` convention out of the Pulumi
CLI and covers every entry point that runs tofu (package add, gen-sdk, and
runtime).

Design: https://app.notion.com/p/Pass-the-Pulumi-access-token-and-API-address-to-providers-37afdbdf1cce80d9afb8fc7f5cd64d8e
Context: https://app.notion.com/p/Terraform-module-hosting-in-the-Pulumi-Cloud-registry-372fdbdf1cce801ea7a3f4946c1e4154

Requires the CLI change in pulumi/pulumi#23589 to supply the credentials.

## Test plan

- Unit: host discovery resolves the registry host from a service-discovery
  document; `TF_TOKEN_<host>` encoding; credentials are scoped to the discovered
  host and not handed to unrelated registries.
- End-to-end against a review stack, using the testbed at
  https://github.com/pulumi/tfmodule-registry-testbed with this provider build
  and the companion CLI. Logged in via `pulumi login`, with
  `PULUMI_ACCESS_TOKEN`, `PULUMI_API`, and `TF_TOKEN_*` unset and the provider
  module cache cleared:
  - `pulumi package add <provider> <registry-host>/<ns>/<name>/<system> <version> <name>`
    generated the SDK — the provider discovered the registry host and
    authenticated with no manual `terraform login`.
  - Logged out, the same command failed with `401 Unauthorized` from the
    registry. The login state is the only difference.
