### PR TITLE
Hoist repeated literals to constants and annotate gosec paths

### DIFF
--- a/pkg/modprovider/module.go
+++ b/pkg/modprovider/module.go
@@ -75,7 +75,7 @@ func (h *moduleHandler) Check(
 
 	_, nameInputProvided := news["name"]
 	inputProperty, hasNameInput := moduleSchema.Inputs["name"]
-	if hasNameInput && inputProperty.Type == "string" && !nameInputProvided {
+	if hasNameInput && inputProperty.Type == stringTypeName && !nameInputProvided {
 		olds := make(map[string]*structpb.Value)
 		if req.Olds != nil && req.Olds.Fields != nil {
 			olds = req.Olds.Fields

--- a/pkg/modprovider/module_test.go
+++ b/pkg/modprovider/module_test.go
@@ -15,14 +15,14 @@ func TestGetStateIncludesModuleVersion(t *testing.T) {
 	props := resource.PropertyMap{
 		resource.PropertyKey(moduleResourceStatePropName):   resource.MakeSecret(resource.NewStringProperty("state-bytes")),
 		resource.PropertyKey(moduleResourceLockPropName):    resource.NewStringProperty("lock-bytes"),
-		resource.PropertyKey(moduleResourceVersionPropName): resource.NewStringProperty("1.2.3"),
+		resource.PropertyKey(moduleResourceVersionPropName): resource.NewStringProperty(version123),
 	}
 
 	state, lock, version := h.getState(props)
 
 	require.Equal(t, []byte("state-bytes"), state)
 	require.Equal(t, []byte("lock-bytes"), lock)
-	require.Equal(t, tfsandbox.TFModuleVersion("1.2.3"), version)
+	require.Equal(t, tfsandbox.TFModuleVersion(version123), version)
 }
 
 func TestNeedsInitUpgrade(t *testing.T) {
@@ -39,20 +39,20 @@ func TestNeedsInitUpgrade(t *testing.T) {
 			name:          "no-old-outputs",
 			oldOutputs:    nil,
 			previous:      "",
-			current:       "1.2.3",
+			current:       version123,
 			expectUpgrade: false,
 		},
 		{
 			name:          "same-version",
 			oldOutputs:    sampleOutputs,
-			previous:      "1.2.3",
-			current:       "1.2.3",
+			previous:      version123,
+			current:       version123,
 			expectUpgrade: false,
 		},
 		{
 			name:          "version-changed",
 			oldOutputs:    sampleOutputs,
-			previous:      "1.2.3",
+			previous:      version123,
 			current:       "1.4.0",
 			expectUpgrade: true,
 		},

--- a/pkg/modprovider/schema_test.go
+++ b/pkg/modprovider/schema_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestParameterizationSpec(t *testing.T) {
-	args := ParameterizeArgs{TFModuleSource: "hashicorp/consul/aws", TFModuleVersion: "0.0.5"}
+	args := ParameterizeArgs{TFModuleSource: consulAwsSource, TFModuleVersion: version005}
 
 	pspec := newParameterizationSpec(&args)
 
@@ -53,21 +53,21 @@ func TestPulumiSchemaForModuleHasLanguageInfoGo(t *testing.T) {
 		{
 			name: "Go module version 0",
 			pArgs: ParameterizeArgs{
-				TFModuleSource:  "hashicorp/consul/aws",
-				TFModuleVersion: "0.0.5",
-				PackageName:     "consul",
+				TFModuleSource:  consulAwsSource,
+				TFModuleVersion: version005,
+				PackageName:     consulPkg,
 			},
-			expectedRootPackageName: "consul",
+			expectedRootPackageName: consulPkg,
 			expectedImportBasePath:  "github.com/pulumi/pulumi-terraform-module/sdks/go/consul/consul",
 		},
 		{
 			name: "Go module version 1",
 			pArgs: ParameterizeArgs{
-				TFModuleSource:  "hashicorp/consul/aws",
-				TFModuleVersion: "1.2.3",
-				PackageName:     "consul",
+				TFModuleSource:  consulAwsSource,
+				TFModuleVersion: version123,
+				PackageName:     consulPkg,
 			},
-			expectedRootPackageName: "consul",
+			expectedRootPackageName: consulPkg,
 			expectedImportBasePath:  "github.com/pulumi/pulumi-terraform-module/sdks/go/consul/consul",
 		},
 		{

--- a/pkg/modprovider/server_test.go
+++ b/pkg/modprovider/server_test.go
@@ -25,6 +25,18 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
+const (
+	version123   = "1.2.3"
+	version005   = "0.0.5"
+	consulPkg    = "consul"
+	awsKey       = "aws"
+	dockerKey    = "docker"
+	opentofuName = "opentofu"
+	vpcIDKey     = "vpc_id"
+
+	consulAwsSource = "hashicorp/consul/aws"
+)
+
 func TestParseParameterizeRequest(t *testing.T) {
 	ctx := context.Background()
 
@@ -32,28 +44,28 @@ func TestParseParameterizeRequest(t *testing.T) {
 		args, err := parseParameterizeRequest(ctx, &pulumirpc.ParameterizeRequest{
 			Parameters: &pulumirpc.ParameterizeRequest_Args{
 				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
-					Args: []string{"hashicorp/consul/aws", "consul"},
+					Args: []string{consulAwsSource, consulPkg},
 				},
 			},
 		})
 		assert.NoError(t, err)
 		// we do not assert on the version because latest is resolved when version isn't specified
-		assert.Equal(t, TFModuleSource("hashicorp/consul/aws"), args.TFModuleSource)
-		assert.Equal(t, packageName("consul"), args.PackageName)
+		assert.Equal(t, TFModuleSource(consulAwsSource), args.TFModuleSource)
+		assert.Equal(t, packageName(consulPkg), args.PackageName)
 	})
 
 	t.Run("parses args with module source and version spec", func(t *testing.T) {
 		args, err := parseParameterizeRequest(ctx, &pulumirpc.ParameterizeRequest{
 			Parameters: &pulumirpc.ParameterizeRequest_Args{
 				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
-					Args: []string{"hashicorp/consul/aws", "0.0.5", "consul"},
+					Args: []string{consulAwsSource, version005, consulPkg},
 				},
 			},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, TFModuleSource("hashicorp/consul/aws"), args.TFModuleSource)
-		assert.Equal(t, TFModuleVersion("0.0.5"), args.TFModuleVersion)
-		assert.Equal(t, packageName("consul"), args.PackageName)
+		assert.Equal(t, TFModuleSource(consulAwsSource), args.TFModuleSource)
+		assert.Equal(t, TFModuleVersion(version005), args.TFModuleVersion)
+		assert.Equal(t, packageName(consulPkg), args.PackageName)
 	})
 
 	t.Run("fails when no args are given", func(t *testing.T) {
@@ -78,9 +90,9 @@ func TestParseParameterizeRequest(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, TFModuleSource("hashicorp/consul/aws"), args.TFModuleSource)
+		assert.Equal(t, TFModuleSource(consulAwsSource), args.TFModuleSource)
 		assert.Equal(t, TFModuleVersion(""), args.TFModuleVersion)
-		assert.Equal(t, packageName("consul"), args.PackageName)
+		assert.Equal(t, packageName(consulPkg), args.PackageName)
 	})
 
 	t.Run("parses github-based remote module source", func(t *testing.T) {
@@ -139,8 +151,8 @@ func TestParseParameterizeRequest(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, TFModuleSource("hashicorp/consul/aws"), args.TFModuleSource)
-		assert.Equal(t, TFModuleVersion("0.0.5"), args.TFModuleVersion)
+		assert.Equal(t, TFModuleSource(consulAwsSource), args.TFModuleSource)
+		assert.Equal(t, TFModuleVersion(version005), args.TFModuleVersion)
 	})
 
 	t.Run("fails when value does not specify the module", func(t *testing.T) {
@@ -165,8 +177,8 @@ func TestParseParameterizeRequestWithConfig(t *testing.T) {
 			Parameters: &pulumirpc.ParameterizeRequest_Args{
 				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
 					Args: []string{
-						"hashicorp/consul/aws",
-						"consul",
+						consulAwsSource,
+						consulPkg,
 						"--config",
 						configFilePath,
 					},
@@ -175,8 +187,8 @@ func TestParseParameterizeRequestWithConfig(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		// we do not assert on the version because latest is resolved when version isn't specified
-		assert.Equal(t, TFModuleSource("hashicorp/consul/aws"), args.TFModuleSource)
-		assert.Equal(t, packageName("consul"), args.PackageName)
+		assert.Equal(t, TFModuleSource(consulAwsSource), args.TFModuleSource)
+		assert.Equal(t, packageName(consulPkg), args.PackageName)
 		assert.NotNil(t, args.Config)
 		assert.NotNil(t, args.Config.InferredModuleSchema)
 		assert.Equal(t, args.Config.InferredModuleSchema, &InferredModuleSchema{
@@ -198,11 +210,11 @@ func Test_cleanProvidersConfig(t *testing.T) {
 	t.Run("json-encoded", func(t *testing.T) {
 		inputConfig := resource.PropertyMap{
 			"version": resource.NewStringProperty("0.0.1"),
-			"aws":     resource.NewStringProperty("{\"region\":\"us-west-2\"}"),
+			awsKey:    resource.NewStringProperty("{\"region\":\"us-west-2\"}"),
 		}
 		cleaned := cleanProvidersConfig(inputConfig)
 		expected := map[string]resource.PropertyMap{
-			"aws": {
+			awsKey: {
 				resource.PropertyKey("region"): resource.NewStringProperty("us-west-2"),
 			},
 		}
@@ -212,13 +224,13 @@ func Test_cleanProvidersConfig(t *testing.T) {
 
 	t.Run("json-encoded-secret", func(t *testing.T) {
 		inputConfig := resource.PropertyMap{
-			"aws": resource.MakeSecret(
+			awsKey: resource.MakeSecret(
 				resource.NewStringProperty("{\"accessKey\":\"my-access-key\"}"),
 			),
 		}
 		cleaned := cleanProvidersConfig(inputConfig)
 		expected := map[string]resource.PropertyMap{
-			"aws": {
+			awsKey: {
 				resource.PropertyKey("accessKey"): resource.NewStringProperty("my-access-key"),
 			},
 		}
@@ -228,13 +240,13 @@ func Test_cleanProvidersConfig(t *testing.T) {
 
 	t.Run("non-json-encoded", func(t *testing.T) {
 		inputConfig := resource.PropertyMap{
-			"docker": resource.NewObjectProperty(resource.PropertyMap{
+			dockerKey: resource.NewObjectProperty(resource.PropertyMap{
 				"local": resource.NewStringProperty("mydockerfile"),
 			}),
 		}
 		cleaned := cleanProvidersConfig(inputConfig)
 		expected := map[string]resource.PropertyMap{
-			"docker": {
+			dockerKey: {
 				resource.PropertyKey("local"): resource.NewStringProperty("mydockerfile"),
 			},
 		}
@@ -243,13 +255,13 @@ func Test_cleanProvidersConfig(t *testing.T) {
 
 	t.Run("non-json-encoded-secret", func(t *testing.T) {
 		inputConfig := resource.PropertyMap{
-			"docker": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			dockerKey: resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
 				"local": resource.NewStringProperty("mydockerfile"),
 			})),
 		}
 		cleaned := cleanProvidersConfig(inputConfig)
 		expected := map[string]resource.PropertyMap{
-			"docker": {
+			dockerKey: {
 				resource.PropertyKey("local"): resource.NewStringProperty("mydockerfile"),
 			},
 		}

--- a/pkg/modprovider/tfmodules.go
+++ b/pkg/modprovider/tfmodules.go
@@ -109,7 +109,12 @@ type InferredModuleSchema struct {
 	SchemaFieldMappings *SchemaFieldMappings                          `json:"schemaFieldMappings,omitempty"`
 }
 
-var stringType = schema.TypeSpec{Type: "string"}
+const (
+	stringTypeName = "string"
+	objectTypeName = "object"
+)
+
+var stringType = schema.TypeSpec{Type: stringTypeName}
 var anyType = schema.TypeSpec{Ref: "pulumi.json#/Any"}
 var boolType = schema.TypeSpec{Type: "boolean"}
 var numberType = schema.TypeSpec{Type: "number"}
@@ -129,7 +134,7 @@ func arrayType(elementType schema.TypeSpec) schema.TypeSpec {
 
 func mapType(elementType schema.TypeSpec) schema.TypeSpec {
 	return schema.TypeSpec{
-		Type:                 "object",
+		Type:                 objectTypeName,
 		AdditionalProperties: &elementType,
 	}
 }
@@ -189,7 +194,7 @@ func convertType(
 
 		complexType := &schema.ComplexTypeSpec{
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Type:       "object",
+				Type:       objectTypeName,
 				Properties: propertiesMap,
 			},
 		}
@@ -669,6 +674,7 @@ type modulesJSONEntry struct {
 }
 
 func readModulesJSON(filePath string) (*modulesJSON, error) {
+	//nolint:gosec // G703: filePath is an internally constructed path to Terraform's modules.json, not user input
 	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read modules.json file: %w", err)

--- a/pkg/modprovider/tfmodules_test.go
+++ b/pkg/modprovider/tfmodules_test.go
@@ -60,7 +60,7 @@ func getExecutorsFromEnv() []string {
 	if executor != "" {
 		return []string{executor}
 	}
-	return []string{"opentofu", "terraform"}
+	return []string{opentofuName, "terraform"}
 }
 
 func TestInferringModuleSchemaWorks(t *testing.T) {
@@ -125,7 +125,7 @@ func TestInferringModuleSchemaWorks(t *testing.T) {
 
 			// verify a sample of the outputs with different inferred types
 			expectedSampleOutputs := map[string]*schema.PropertySpec{
-				"vpc_id": {
+				vpcIDKey: {
 					Description: "The ID of the VPC",
 					Secret:      false,
 					TypeSpec:    stringType,
@@ -215,7 +215,7 @@ func TestParsingModuleSchemaOverrides(t *testing.T) {
 	assert.Equal(t, testSchemaOverride.PartialSchema.SupportingTypes, map[string]*schema.ComplexTypeSpec{
 		"vpc:index:MyType": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Type:        "object",
+				Type:        objectTypeName,
 				Description: "An example supporting type for the module.",
 				Properties: map[string]schema.PropertySpec{
 					"example_property": {
@@ -257,7 +257,7 @@ func TestApplyModuleOverrides(t *testing.T) {
 						Source:         string(source),
 						MaximumVersion: "6.0.0",
 						PartialSchema: &InferredModuleSchema{
-							NonNilOutputs:  []resource.PropertyKey{"vpc_id"},
+							NonNilOutputs:  []resource.PropertyKey{vpcIDKey},
 							RequiredInputs: []resource.PropertyKey{"cidr"},
 						},
 					},
@@ -267,7 +267,7 @@ func TestApplyModuleOverrides(t *testing.T) {
 				assert.True(t, ok, "module schema overrides should be found")
 				overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
 				assert.NotNil(t, overridenSchema, "overridden module schema is nil")
-				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey("vpc_id"), "vpc_id should be required")
+				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey(vpcIDKey), "vpc_id should be required")
 				assert.Contains(t, overridenSchema.RequiredInputs, resource.PropertyKey("cidr"), "cidr should be required")
 			})
 
@@ -278,7 +278,7 @@ func TestApplyModuleOverrides(t *testing.T) {
 						MaximumVersion: "6.0.0",
 						PartialSchema: &InferredModuleSchema{
 							Outputs: map[resource.PropertyKey]*schema.PropertySpec{
-								"vpc_id": {
+								vpcIDKey: {
 									Description: "The new ID field of the VPC",
 									Secret:      true,
 								},
@@ -291,13 +291,13 @@ func TestApplyModuleOverrides(t *testing.T) {
 				assert.True(t, ok, "module schema overrides should be found")
 				overridenSchema := combineInferredModuleSchema(awsVpcSchema, partialAwsVpcSchemaOverride)
 				assert.NotNil(t, overridenSchema, "overridden module schema is nil")
-				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey("vpc_id"), "vpc_id should be non-nil")
+				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey(vpcIDKey), "vpc_id should be non-nil")
 
-				vpcID := overridenSchema.Outputs["vpc_id"]
+				vpcID := overridenSchema.Outputs[vpcIDKey]
 				assert.Equal(t, "The new ID field of the VPC", vpcID.Description, "vpc_id description should be updated")
 				assert.True(t, vpcID.Secret, "vpc_id should be secret")
-				assert.Equal(t, "string", vpcID.Type, "vpc_id type should not be changed")
-				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey("vpc_id"), "vpc_id should be non-nil")
+				assert.Equal(t, stringTypeName, vpcID.Type, "vpc_id type should not be changed")
+				assert.Contains(t, overridenSchema.NonNilOutputs, resource.PropertyKey(vpcIDKey), "vpc_id should be non-nil")
 			})
 		})
 	}
@@ -326,7 +326,7 @@ func TestInferringInputsFromLocalPath(t *testing.T) {
 	src := filepath.Join("..", "..", "tests", "testdata", "modules", "schema-inference-example")
 	p, err := filepath.Abs(src)
 	require.NoError(t, err)
-	for _, executor := range []string{"terraforn", "opentofu"} {
+	for _, executor := range []string{"terraforn", opentofuName} {
 		logger := newTestLogger(t)
 		t.Run("executor="+executor, func(t *testing.T) {
 			tf := newTestRuntime(t, executor)
@@ -420,7 +420,7 @@ func TestInferringSchemaWithDashedFielsFromLocalPath(t *testing.T) {
 	src := filepath.Join("..", "..", "tests", "testdata", "modules", "dashed-module-fields")
 	p, err := filepath.Abs(src)
 	require.NoError(t, err)
-	for _, executor := range []string{"terraforn", "opentofu"} {
+	for _, executor := range []string{"terraforn", opentofuName} {
 		logger := newTestLogger(t)
 		t.Run("executor="+executor, func(t *testing.T) {
 			tf := newTestRuntime(t, executor)
@@ -614,7 +614,7 @@ func TestInferModuleSchemaFromGitHubSourceWithSubModuleAndVersion(t *testing.T) 
 func TestInferRequiredInputsWorks(t *testing.T) {
 	ctx := context.Background()
 	packageName := packageName("http")
-	for _, executor := range []string{"terraform", "opentofu"} {
+	for _, executor := range []string{"terraform", opentofuName} {
 		t.Run("executor="+executor, func(t *testing.T) {
 			source := TFModuleSource("terraform-aws-modules/security-group/aws//modules/http-80")
 			version := TFModuleVersion("5.3.0")
@@ -622,7 +622,7 @@ func TestInferRequiredInputsWorks(t *testing.T) {
 			httpSchema, err := InferModuleSchema(ctx, tf, packageName, source, version)
 			assert.NoError(t, err, "failed to infer module schema for aws vpc module")
 			assert.NotNil(t, httpSchema, "inferred module schema for aws vpc module is nil")
-			assert.Contains(t, httpSchema.RequiredInputs, resource.PropertyKey("vpc_id"))
+			assert.Contains(t, httpSchema.RequiredInputs, resource.PropertyKey(vpcIDKey))
 		})
 	}
 }

--- a/pkg/pulumix/property_test.go
+++ b/pkg/pulumix/property_test.go
@@ -30,6 +30,11 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
+const (
+	fooKey    = "foo"
+	moduleURN = "urn:pulumi:test::prog::randmod:index:Module::mymod"
+)
+
 // Check that UnmarshalProperties(pm) passes over the gRPC wire RegisterResource call without distortion.
 func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 	type testCase struct {
@@ -44,30 +49,30 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 		{
 			name: "number",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewNumberProperty(42),
+				fooKey: resource.NewNumberProperty(42),
 			},
 		},
 		{
 			name: "string",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewStringProperty("foo"),
+				fooKey: resource.NewStringProperty(fooKey),
 			},
 		},
 		{
 			name: "bool",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewBoolProperty(true),
+				fooKey: resource.NewBoolProperty(true),
 			},
 		},
 		{
 			name: "unknown",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewComputedProperty(resource.Computed{
+				fooKey: resource.NewComputedProperty(resource.Computed{
 					Element: resource.NewStringProperty(""),
 				}),
 			},
 			inputsReceived: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
+				fooKey: resource.NewOutputProperty(resource.Output{
 					Known: false,
 				}),
 			},
@@ -75,12 +80,12 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 		{
 			name: "secret",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewSecretProperty(&resource.Secret{
+				fooKey: resource.NewSecretProperty(&resource.Secret{
 					Element: resource.NewStringProperty("SECRET"),
 				}),
 			},
 			inputsReceived: resource.PropertyMap{
-				"foo": resource.NewOutputProperty(resource.Output{
+				fooKey: resource.NewOutputProperty(resource.Output{
 					Known:   true,
 					Secret:  true,
 					Element: resource.NewStringProperty("SECRET"),
@@ -90,8 +95,8 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 		{
 			name: "array",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewArrayProperty([]resource.PropertyValue{
-					resource.NewStringProperty("foo"),
+				fooKey: resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewStringProperty(fooKey),
 					resource.NewNumberProperty(42.0),
 				}),
 			},
@@ -99,8 +104,8 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 		{
 			name: "object",
 			inputs: resource.PropertyMap{
-				"foo": resource.NewObjectProperty(resource.PropertyMap{
-					"p1": resource.NewStringProperty("foo"),
+				fooKey: resource.NewObjectProperty(resource.PropertyMap{
+					"p1": resource.NewStringProperty(fooKey),
 					"p2": resource.NewNumberProperty(42.0),
 				}),
 			},
@@ -142,7 +147,7 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 					Element: resource.NewStringProperty("value"),
 					Known:   true,
 					Dependencies: []urn.URN{
-						"urn:pulumi:test::prog::randmod:index:Module::mymod",
+						moduleURN,
 					},
 				}),
 			},
@@ -153,7 +158,7 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 				"x": resource.NewOutputProperty(resource.Output{
 					Known: false,
 					Dependencies: []urn.URN{
-						"urn:pulumi:test::prog::randmod:index:Module::mymod",
+						moduleURN,
 					},
 				}),
 			},
@@ -166,7 +171,7 @@ func TestUnmarhsalPropertiesThreadThroughRegisterResource(t *testing.T) {
 					Known:   true,
 					Secret:  true,
 					Dependencies: []urn.URN{
-						"urn:pulumi:test::prog::randmod:index:Module::mymod",
+						moduleURN,
 						"urn:pulumi:test::prog::randmod:index:Module::mymod2",
 					},
 				}),

--- a/pkg/tfsandbox/details_test.go
+++ b/pkg/tfsandbox/details_test.go
@@ -417,7 +417,7 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 					bucketNameKey: myBucketVal,
 				},
 			},
-			sensitiveValues: []byte(`{bucketNameKey: true}`),
+			sensitiveValues: []byte(`{"bucketName": true}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
 				bucketNameKey: resource.MakeSecret(resource.NewStringProperty(myBucketVal)),
 			}),
@@ -445,7 +445,7 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 					bucketNameKey: myBucketVal,
 				},
 			},
-			sensitiveValues: []byte(`{bucketNameKey: {}}`),
+			sensitiveValues: []byte(`{"bucketName": {}}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
 				bucketNameKey: resource.NewStringProperty(myBucketVal),
 			}),
@@ -465,7 +465,7 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 					},
 				},
 			},
-			sensitiveValues: []byte(`{nestedPropsKey: true}`),
+			sensitiveValues: []byte(`{"nestedProps": true}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
 				nestedPropsKey: resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
@@ -489,7 +489,7 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 					},
 				},
 			},
-			sensitiveValues: []byte(`{nestedPropsKey: [{nestedProp2Key: true},{nestedProp1Key: false}]}`),
+			sensitiveValues: []byte(`{"nestedProps": [{"nestedProp2": true},{"nestedProp1": false}]}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
 				nestedPropsKey: []interface{}{
 					map[string]interface{}{
@@ -519,7 +519,7 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 					},
 				},
 			},
-			sensitiveValues: []byte(`{nestedPropsKey: [true,{nestedProp1Key: true},{nestedProp2Key: false},false]}`),
+			sensitiveValues: []byte(`{"nestedProps": [true,{"nestedProp1": true},{"nestedProp2": false},false]}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
 				nestedPropsKey: []interface{}{
 					resource.MakeSecret(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{

--- a/pkg/tfsandbox/details_test.go
+++ b/pkg/tfsandbox/details_test.go
@@ -28,6 +28,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+const (
+	awsS3BucketType     = "aws_s3_bucket"
+	awsS3BucketAddress  = "aws_s3_bucket.this"
+	bucketNameKey       = "bucketName"
+	nestedPropsKey      = "nestedProps"
+	nestedProp1Key      = "nestedProp1"
+	nestedProp2Key      = "nestedProp2"
+	nestedNestedPropKey = "nestedNestedProp"
+	testValue           = "value"
+	myBucketVal         = "my-bucket"
+)
+
 func Test_extractPropertyMapFromPlan(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -38,37 +50,37 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 		{
 			name: "no resource changes",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"bucketName": "my-bucket",
+					bucketNameKey: myBucketVal,
 				},
 			},
 			resourceChange: nil,
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": "my-bucket",
+				bucketNameKey: myBucketVal,
 			}),
 		},
 		{
 			// This is one way that unknowns appear in AttributeValues (as nil)
 			name: "AfterUnknown=true - AttributeValues property is nil",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"bucketName": nil,
+					bucketNameKey: nil,
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"bucketName": true,
+						bucketNameKey: true,
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": resource.MakeComputed(resource.NewStringProperty("")),
+				bucketNameKey: resource.MakeComputed(resource.NewStringProperty("")),
 			}),
 		},
 		{
@@ -76,20 +88,20 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 			// AfterUnknown is the source of truth
 			name: "AfterUnknown=true - AttributeValues property is missing",
 			stateResource: tfjson.StateResource{
-				Type:            "aws_s3_bucket",
-				Address:         "aws_s3_bucket.this",
+				Type:            awsS3BucketType,
+				Address:         awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"bucketName": true,
+						bucketNameKey: true,
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": resource.MakeComputed(resource.NewStringProperty("")),
+				bucketNameKey: resource.MakeComputed(resource.NewStringProperty("")),
 			}),
 		},
 		{
@@ -97,26 +109,26 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 			// is marked as unknown in AfterUnknown.
 			name: "AfterUnknown=true (top level) - AttributeValues property is complex type",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []map[string]interface{}{
+					nestedPropsKey: []map[string]interface{}{
 						{
-							"nestedProp2": "value",
+							nestedProp2Key: testValue,
 						},
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": true,
+						nestedPropsKey: true,
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": resource.MakeComputed(resource.NewStringProperty("")),
+				nestedPropsKey: resource.MakeComputed(resource.NewStringProperty("")),
 			}),
 		},
 		{
@@ -124,68 +136,68 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 			// If a value is "unknown" it won't also be marked as sensitive
 			name: "AfterUnknown=true and AfterSensitive=true - AttributeValues property is complex type",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []map[string]interface{}{
+					nestedPropsKey: []map[string]interface{}{
 						{
-							"nestedProp2": "value",
+							nestedProp2Key: testValue,
 						},
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": true,
+						nestedPropsKey: true,
 					},
 					AfterSensitive: map[string]interface{}{
-						"nestedProps": []map[string]interface{}{
+						nestedPropsKey: []map[string]interface{}{
 							{
-								"nestedProp2": true,
+								nestedProp2Key: true,
 							},
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": resource.MakeComputed(resource.NewStringProperty("")),
+				nestedPropsKey: resource.MakeComputed(resource.NewStringProperty("")),
 			}),
 		},
 		{
 			// Only those nested properties that are marked as unknown in AfterUnknown should be updated
 			name: "AfterUnknown=true (nested in array) - AttributeValues nested property is nil",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						map[string]interface{}{
-							"nestedProp1": nil,
-							"nestedProp2": "value",
+							nestedProp1Key: nil,
+							nestedProp2Key: testValue,
 						},
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": []interface{}{
+						nestedPropsKey: []interface{}{
 							map[string]interface{}{
-								"nestedProp1": true,
-								"nestedProp2": false,
+								nestedProp1Key: true,
+								nestedProp2Key: false,
 							},
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					map[string]interface{}{
-						"nestedProp1": resource.MakeComputed(resource.NewStringProperty("")),
-						"nestedProp2": resource.NewStringProperty("value"),
+						nestedProp1Key: resource.MakeComputed(resource.NewStringProperty("")),
+						nestedProp2Key: resource.NewStringProperty(testValue),
 					},
 				},
 			}),
@@ -193,26 +205,26 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 		{
 			name: "AfterUnknown=true (in array) - AttributeValues nested value is nil",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						"",
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": []interface{}{
+						nestedPropsKey: []interface{}{
 							true,
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					resource.MakeComputed(resource.NewStringProperty("")),
 				},
 			}),
@@ -220,21 +232,21 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 		{
 			name: "AfterUnknown mixed (in array) - AttributeValues mixed",
 			stateResource: tfjson.StateResource{
-				Type:            "aws_s3_bucket",
-				Address:         "aws_s3_bucket.this",
+				Type:            awsS3BucketType,
+				Address:         awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": []interface{}{
+						nestedPropsKey: []interface{}{
 							true,
 							map[string]interface{}{
-								"nestedProp1": true,
+								nestedProp1Key: true,
 							},
 							map[string]interface{}{
-								"nestedProp2": false,
+								nestedProp2Key: false,
 							},
 							false,
 						},
@@ -242,10 +254,10 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					resource.MakeComputed(resource.NewStringProperty("")),
 					map[string]interface{}{
-						"nestedProp1": resource.MakeComputed(resource.NewStringProperty("")),
+						nestedProp1Key: resource.MakeComputed(resource.NewStringProperty("")),
 					},
 				},
 			}),
@@ -253,32 +265,32 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 		{
 			name: "AfterUnknown (in array) - AttributeValues shorter length",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						"",
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": []interface{}{
+						nestedPropsKey: []interface{}{
 							true,
 							map[string]interface{}{
-								"nestedProp1": true,
+								nestedProp1Key: true,
 							},
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					resource.MakeComputed(resource.NewStringProperty("")),
 					map[string]interface{}{
-						"nestedProp1": resource.MakeComputed(resource.NewStringProperty("")),
+						nestedProp1Key: resource.MakeComputed(resource.NewStringProperty("")),
 					},
 				},
 			}),
@@ -286,24 +298,24 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 		{
 			name: "AfterUnknown (in array) - AttributeValues longer length",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						"abc",
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": []interface{}{},
+						nestedPropsKey: []interface{}{},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					resource.NewStringProperty("abc"),
 				},
 			}),
@@ -314,33 +326,33 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 			// We should add the missing nested property structure
 			name: "AfterUnknown=true (nested in object) - AttributeValues nested property is missing",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": map[string]interface{}{
-						"nestedProp2": "value",
+					nestedPropsKey: map[string]interface{}{
+						nestedProp2Key: testValue,
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": map[string]interface{}{
-							"nestedProp1": map[string]interface{}{
-								"nestedNestedProp": true,
+						nestedPropsKey: map[string]interface{}{
+							nestedProp1Key: map[string]interface{}{
+								nestedNestedPropKey: true,
 							},
-							"nestedProp2": false,
+							nestedProp2Key: false,
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": map[string]interface{}{
-					"nestedProp1": map[string]interface{}{
-						"nestedNestedProp": resource.MakeComputed(resource.NewStringProperty("")),
+				nestedPropsKey: map[string]interface{}{
+					nestedProp1Key: map[string]interface{}{
+						nestedNestedPropKey: resource.MakeComputed(resource.NewStringProperty("")),
 					},
-					"nestedProp2": resource.NewStringProperty("value"),
+					nestedProp2Key: resource.NewStringProperty(testValue),
 				},
 			}),
 		},
@@ -351,30 +363,30 @@ func Test_extractPropertyMapFromPlan(t *testing.T) {
 			// We should not add the missing nested property structure
 			name: "AfterUnknown=false (nested in object) - AttributeValues nested property is missing",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": map[string]interface{}{
-						"nestedProp2": "value",
+					nestedPropsKey: map[string]interface{}{
+						nestedProp2Key: testValue,
 					},
 				},
 			},
 			resourceChange: &tfjson.ResourceChange{
-				Address: "aws_s3_bucket.this",
+				Address: awsS3BucketAddress,
 				Change: &tfjson.Change{
 					AfterUnknown: map[string]interface{}{
-						"nestedProps": map[string]interface{}{
-							"nestedProp1": map[string]interface{}{
-								"nestedNestedProp": false,
+						nestedPropsKey: map[string]interface{}{
+							nestedProp1Key: map[string]interface{}{
+								nestedNestedPropKey: false,
 							},
-							"nestedProp2": false,
+							nestedProp2Key: false,
 						},
 					},
 				},
 			},
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": map[string]interface{}{
-					"nestedProp2": resource.NewStringProperty("value"),
+				nestedPropsKey: map[string]interface{}{
+					nestedProp2Key: resource.NewStringProperty(testValue),
 				},
 			}),
 		},
@@ -399,43 +411,43 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 		{
 			name: "string value",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"bucketName": "my-bucket",
+					bucketNameKey: myBucketVal,
 				},
 			},
-			sensitiveValues: []byte(`{"bucketName": true}`),
+			sensitiveValues: []byte(`{bucketNameKey: true}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": resource.MakeSecret(resource.NewStringProperty("my-bucket")),
+				bucketNameKey: resource.MakeSecret(resource.NewStringProperty(myBucketVal)),
 			}),
 		},
 		{
 			name: "SensitiveValues property is nil",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"bucketName": "my-bucket",
+					bucketNameKey: myBucketVal,
 				},
 			},
 			sensitiveValues: []byte(`{}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": resource.NewStringProperty("my-bucket"),
+				bucketNameKey: resource.NewStringProperty(myBucketVal),
 			}),
 		},
 		{
 			name: "SensitiveValues key is nil",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"bucketName": "my-bucket",
+					bucketNameKey: myBucketVal,
 				},
 			},
-			sensitiveValues: []byte(`{"bucketName": {}}`),
+			sensitiveValues: []byte(`{bucketNameKey: {}}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"bucketName": resource.NewStringProperty("my-bucket"),
+				bucketNameKey: resource.NewStringProperty(myBucketVal),
 			}),
 		},
 		{
@@ -443,21 +455,21 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 			// is marked as secret.
 			name: "Sensitive=true (top level) - AttributeValues property is complex type",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []map[string]interface{}{
+					nestedPropsKey: []map[string]interface{}{
 						{
-							"nestedProp2": "value",
+							nestedProp2Key: testValue,
 						},
 					},
 				},
 			},
-			sensitiveValues: []byte(`{"nestedProps": true}`),
+			sensitiveValues: []byte(`{nestedPropsKey: true}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+				nestedPropsKey: resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"nestedProp2": resource.NewStringProperty("value"),
+						nestedProp2Key: resource.NewStringProperty(testValue),
 					}),
 				})),
 			}),
@@ -466,23 +478,23 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 			// Only those nested properties that are marked as sensitive should be updated
 			name: "Sensitive=true (nested in array)",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						map[string]interface{}{
-							"nestedProp2": "value",
-							"nestedProp1": "value",
+							nestedProp2Key: testValue,
+							nestedProp1Key: testValue,
 						},
 					},
 				},
 			},
-			sensitiveValues: []byte(`{"nestedProps": [{"nestedProp2": true},{"nestedProp1": false}]}`),
+			sensitiveValues: []byte(`{nestedPropsKey: [{nestedProp2Key: true},{nestedProp1Key: false}]}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					map[string]interface{}{
-						"nestedProp2": resource.MakeSecret(resource.NewStringProperty("value")),
-						"nestedProp1": resource.NewStringProperty("value"),
+						nestedProp2Key: resource.MakeSecret(resource.NewStringProperty(testValue)),
+						nestedProp1Key: resource.NewStringProperty(testValue),
 					},
 				},
 			}),
@@ -490,36 +502,36 @@ func Test_extractPropertyMapFromState(t *testing.T) {
 		{
 			name: "Sensitive mixed (in array) - AttributeValues mixed",
 			stateResource: tfjson.StateResource{
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.this",
+				Type:    awsS3BucketType,
+				Address: awsS3BucketAddress,
 				AttributeValues: map[string]interface{}{
-					"nestedProps": []interface{}{
+					nestedPropsKey: []interface{}{
 						map[string]interface{}{
-							"nestedProp2": "value",
+							nestedProp2Key: testValue,
 						},
 						map[string]interface{}{
-							"nestedProp1": "value",
+							nestedProp1Key: testValue,
 						},
 						map[string]interface{}{
-							"nestedProp2": "value",
+							nestedProp2Key: testValue,
 						},
-						"value",
+						testValue,
 					},
 				},
 			},
-			sensitiveValues: []byte(`{"nestedProps": [true,{"nestedProp1": true},{"nestedProp2": false},false]}`),
+			sensitiveValues: []byte(`{nestedPropsKey: [true,{nestedProp1Key: true},{nestedProp2Key: false},false]}`),
 			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
-				"nestedProps": []interface{}{
+				nestedPropsKey: []interface{}{
 					resource.MakeSecret(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-						"nestedProp2": "value",
+						nestedProp2Key: testValue,
 					}))),
 					resource.NewPropertyMapFromMap(map[string]interface{}{
-						"nestedProp1": resource.MakeSecret(resource.NewStringProperty("value")),
+						nestedProp1Key: resource.MakeSecret(resource.NewStringProperty(testValue)),
 					}),
 					resource.NewPropertyMapFromMap(map[string]interface{}{
-						"nestedProp2": resource.NewStringProperty("value"),
+						nestedProp2Key: resource.NewStringProperty(testValue),
 					}),
-					resource.NewStringProperty("value"),
+					resource.NewStringProperty(testValue),
 				},
 			}),
 		},
@@ -600,7 +612,7 @@ func TestCreatePlan(t *testing.T) {
 	rBucket, ok := p.FindResourcePlan("module.s3_bucket.aws_s3_bucket.this[0]")
 	require.True(t, ok)
 	assert.Equal(t, ResourceAddress("module.s3_bucket.aws_s3_bucket.this[0]"), rBucket.Address())
-	assert.Equal(t, TFResourceType("aws_s3_bucket"), rBucket.Type())
+	assert.Equal(t, TFResourceType(awsS3BucketType), rBucket.Type())
 	assert.Equal(t, Create, rBucket.ChangeKind())
 
 	plannedValues, ok := rBucket.PlannedValues()

--- a/pkg/tfsandbox/runtime.go
+++ b/pkg/tfsandbox/runtime.go
@@ -34,6 +34,8 @@ import (
 	"github.com/pulumi/pulumi-terraform-module/pkg/tofuresolver"
 )
 
+const terraformName = "terraform"
+
 type ModuleRuntime struct {
 	tf          *tfexec.Terraform
 	reattach    *tfexec.ReattachInfo
@@ -168,12 +170,12 @@ func NewTerraform(ctx context.Context, logger Logger, workdir Workdir, auxServer
 
 	tfInfo := fs.AnyVersion{
 		Product: &product.Product{
-			Name: "terraform",
+			Name: terraformName,
 			BinaryName: func() string {
 				if runtime.GOOS == "windows" {
 					return "terraform.exe"
 				}
-				return "terraform"
+				return terraformName
 			},
 		},
 	}

--- a/pkg/tfsandbox/runtime_test.go
+++ b/pkg/tfsandbox/runtime_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+const (
+	inputVarKey = "inputVar"
+	testStr     = "test"
+)
+
 func TestTofuInit(t *testing.T) {
 	tofu := newTestTofu(t)
 	t.Logf("WorkingDir: %s", tofu.WorkingDir())
@@ -64,8 +69,8 @@ func TestTofuPlan(t *testing.T) {
 	outputs := []TFOutputSpec{}
 	providersConfig := map[string]resource.PropertyMap{}
 	ms := TFModuleSource(path.Join(getCwd(t), "testdata", "modules", "test_module"))
-	err := CreateTFFile("test", ms, "", tofu.WorkingDir(), resource.NewPropertyMapFromMap(map[string]interface{}{
-		"inputVar": "test",
+	err := CreateTFFile(testStr, ms, "", tofu.WorkingDir(), resource.NewPropertyMapFromMap(map[string]interface{}{
+		inputVarKey: testStr,
 	}), outputs, providersConfig)
 	assert.NoErrorf(t, err, "error creating tf file")
 
@@ -88,8 +93,8 @@ func TestTofuApply(t *testing.T) {
 	emptyOutputs := []TFOutputSpec{}
 	ms := TFModuleSource(path.Join(getCwd(t), "testdata", "modules", "test_module"))
 	providersConfig := map[string]resource.PropertyMap{}
-	err := CreateTFFile("test", ms, "", tofu.WorkingDir(), resource.NewPropertyMapFromMap(map[string]interface{}{
-		"inputVar": "test",
+	err := CreateTFFile(testStr, ms, "", tofu.WorkingDir(), resource.NewPropertyMapFromMap(map[string]interface{}{
+		inputVarKey: testStr,
 	}), emptyOutputs, providersConfig)
 	assert.NoErrorf(t, err, "error creating tf file")
 

--- a/pkg/tfsandbox/state_test.go
+++ b/pkg/tfsandbox/state_test.go
@@ -30,10 +30,10 @@ import (
 
 func TestState(t *testing.T) {
 	ctx := context.Background()
-	for _, executor := range []string{"terraform", "tofu"} {
+	for _, executor := range []string{terraformName, "tofu"} {
 		t.Run("executor="+executor, func(t *testing.T) {
 			var tf *ModuleRuntime
-			if executor == "terraform" {
+			if executor == terraformName {
 				tf = newTestTerraform(t)
 			} else {
 				tf = newTestTofu(t)
@@ -49,9 +49,9 @@ func TestState(t *testing.T) {
 
 			providersConfig := map[string]resource.PropertyMap{}
 			ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
-			err := CreateTFFile("test", ms, "", tf.WorkingDir(),
+			err := CreateTFFile(testStr, ms, "", tf.WorkingDir(),
 				resource.NewPropertyMapFromMap(map[string]interface{}{
-					"inputVar": "test",
+					inputVarKey: testStr,
 				}), outputs, providersConfig)
 			require.NoError(t, err, "error creating tf file")
 
@@ -74,7 +74,7 @@ func TestState(t *testing.T) {
 
 			moduleOutputs := state.Outputs()
 			// output value is the same as the input
-			expectedOutputValue := resource.NewStringProperty("test")
+			expectedOutputValue := resource.NewStringProperty(testStr)
 			require.Equal(t, resource.PropertyMap{
 				resource.PropertyKey("output1"):          expectedOutputValue,
 				resource.PropertyKey("sensitive_output"): resource.MakeSecret(expectedOutputValue),
@@ -155,13 +155,13 @@ func TestStateMatchesPlan(t *testing.T) {
 			}
 			ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
 			inputs := map[string]interface{}{
-				"inputVar": "test",
+				inputVarKey: testStr,
 			}
 			if tc.inputNumberVar != nil {
 				inputs["inputNumberVar"] = tc.inputNumberVar
 			}
 			emptyProviders := map[string]resource.PropertyMap{}
-			err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
+			err := CreateTFFile(testStr, ms, "", tofu.WorkingDir(),
 				resource.NewPropertyMapFromMap(inputs), outputs, emptyProviders)
 			require.NoError(t, err, "error creating tf file")
 
@@ -214,11 +214,11 @@ func TestSecretOutputs(t *testing.T) {
 		}
 		ms := TFModuleSource(filepath.Join(getCwd(t), "testdata", "modules", "test_module"))
 		inputs := map[string]any{
-			"inputVar":        "test",
+			inputVarKey:       testStr,
 			"anotherInputVar": resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("somevalue")}),
 		}
 		emptyProviders := map[string]resource.PropertyMap{}
-		err := CreateTFFile("test", ms, "", tofu.WorkingDir(),
+		err := CreateTFFile(testStr, ms, "", tofu.WorkingDir(),
 			resource.NewPropertyMapFromMap(inputs), outputs, emptyProviders)
 		require.NoError(t, err, "error creating tf file")
 
@@ -241,9 +241,9 @@ func TestSecretOutputs(t *testing.T) {
 			resource.PropertyKey("nested_sensitive_output"): resource.MakeSecret(
 				resource.NewObjectProperty(
 					resource.NewPropertyMapFromMap(map[string]any{
-						"A": resource.NewStringProperty("test"),
+						"A": resource.NewStringProperty(testStr),
 						"B": resource.NewStringProperty("somevalue"),
-						"C": resource.NewStringProperty("test"),
+						"C": resource.NewStringProperty(testStr),
 					}))),
 		}, moduleOutputs)
 	})

--- a/pkg/tfsandbox/tf_file.go
+++ b/pkg/tfsandbox/tf_file.go
@@ -230,10 +230,12 @@ func CreateTFFile(
 	for _, output := range outputs {
 		mOutputs[output.Name] = map[string]any{
 			// wrapping in jsondecode/jsonencode to workaround an issue where nonsensitive/issensitive is not recursive
-			"value": fmt.Sprintf("${jsondecode(nonsensitive(jsonencode(module.%s.%s)))}", name, output.Name),
+			unknownProxyResourceOutputProp: fmt.Sprintf(
+				"${jsondecode(nonsensitive(jsonencode(module.%s.%s)))}", name, output.Name),
 		}
 		mOutputs[fmt.Sprintf("%s%s", terraformIsSecretOutputPrefix, output.Name)] = map[string]any{
-			"value": fmt.Sprintf("${jsondecode(issensitive(jsonencode(module.%s.%s)))}", name, output.Name),
+			unknownProxyResourceOutputProp: fmt.Sprintf(
+				"${jsondecode(issensitive(jsonencode(module.%s.%s)))}", name, output.Name),
 		}
 	}
 

--- a/pkg/tfsandbox/tf_file_test.go
+++ b/pkg/tfsandbox/tf_file_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+const (
+	stringType             = "string"
+	keyKey                 = "key"
+	key1Key                = "key1"
+	key2Key                = "key2"
+	key3Key                = "key3"
+	value1Val              = "value1"
+	local1Key              = "local1"
+	nestedKeyKey           = "nestedKey"
+	nestedKey2Key          = "nestedKey2"
+	stringValKey           = "string_val"
+	numberValKey           = "number_val"
+	listMapStringType      = "list(map(string))"
+	mapMapAnyType          = "map(map(any))"
+	objectStringNumberType = "object({string_val=string, number_val=number})"
+	unknownProxyValueRef   = "${pulumiaux_unk.unknown_proxy.value}"
+	sensitiveLocal1Ref     = "${sensitive(local.local1)}"
+)
+
 func writeTfVarFile(t *testing.T, workingDir string, varType string) {
 	t.Helper()
 	tfVarFile := fmt.Sprintf(`
@@ -44,19 +63,19 @@ func TestCreateTFFile(t *testing.T) {
 		usesUnknowns    bool
 	}{
 		{
-			name:           "string",
-			tfVariableType: "string",
+			name:           stringType,
+			tfVariableType: stringType,
 			inputsValue:    resource.NewStringProperty("hello"),
 		},
 		{
 			name:           "unknown",
-			tfVariableType: "string",
+			tfVariableType: stringType,
 			inputsValue:    resource.MakeComputed(resource.NewStringProperty("")),
 			usesUnknowns:   true,
 		},
 		{
 			name:           "string secret",
-			tfVariableType: "string",
+			tfVariableType: stringType,
 			inputsValue:    resource.NewSecretProperty(&resource.Secret{Element: resource.NewStringProperty("hello")}),
 		},
 		{
@@ -81,42 +100,42 @@ func TestCreateTFFile(t *testing.T) {
 			name:           "map(string)",
 			tfVariableType: "map(string)",
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewStringProperty("value"),
+				keyKey: resource.NewStringProperty(testValue),
 			}),
 		},
 		{
-			name:           "list(map(string))",
-			tfVariableType: "list(map(string))",
+			name:           listMapStringType,
+			tfVariableType: listMapStringType,
 			inputsValue: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewObjectProperty(resource.PropertyMap{
-					"key": resource.NewStringProperty("value"),
+					keyKey: resource.NewStringProperty(testValue),
 				}),
 			}),
 		},
 		{
 			name:           "unknown list(map(string))",
-			tfVariableType: "list(map(string))",
+			tfVariableType: listMapStringType,
 			inputsValue: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewObjectProperty(resource.PropertyMap{"key": resource.MakeComputed(resource.NewStringProperty(""))}),
+				resource.NewObjectProperty(resource.PropertyMap{keyKey: resource.MakeComputed(resource.NewStringProperty(""))}),
 			}),
 			usesUnknowns: true,
 		},
 		{
-			name:           "map(map(any))",
-			tfVariableType: "map(map(any))",
+			name:           mapMapAnyType,
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(resource.PropertyMap{
-					"key": resource.NewStringProperty("value"),
+				keyKey: resource.NewObjectProperty(resource.PropertyMap{
+					keyKey: resource.NewStringProperty(testValue),
 				}),
 			}),
 		},
 		{
 			name:           "unknown map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(
+				keyKey: resource.NewObjectProperty(
 					resource.PropertyMap{
-						"key": resource.MakeComputed(resource.NewStringProperty("")),
+						keyKey: resource.MakeComputed(resource.NewStringProperty("")),
 					},
 				),
 			}),
@@ -132,56 +151,56 @@ func TestCreateTFFile(t *testing.T) {
 		},
 		{
 			name:           "object type",
-			tfVariableType: "object({string_val=string, number_val=number})",
+			tfVariableType: objectStringNumberType,
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"string_val": resource.NewStringProperty("hello"),
-				"number_val": resource.NewNumberProperty(42),
+				stringValKey: resource.NewStringProperty("hello"),
+				numberValKey: resource.NewNumberProperty(42),
 			}),
 		},
 		{
 			name:           "unknown object type",
-			tfVariableType: "object({string_val=string, number_val=number})",
+			tfVariableType: objectStringNumberType,
 			inputsValue: resource.NewObjectProperty(
 				resource.PropertyMap{
-					"string_val": resource.MakeComputed(resource.NewStringProperty("hello")),
-					"number_val": resource.NewNumberProperty(42),
+					stringValKey: resource.MakeComputed(resource.NewStringProperty("hello")),
+					numberValKey: resource.NewNumberProperty(42),
 				},
 			),
 			usesUnknowns: true,
 		},
 		{
 			name:           "secret list(map(string))",
-			tfVariableType: "list(map(string))",
+			tfVariableType: listMapStringType,
 			inputsValue: resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewObjectProperty(resource.PropertyMap{"key": resource.NewStringProperty("value")}),
+				resource.NewObjectProperty(resource.PropertyMap{keyKey: resource.NewStringProperty(testValue)}),
 			})),
 		},
 		{
 			name:           "output secret list(map(string))",
-			tfVariableType: "list(map(string))",
+			tfVariableType: listMapStringType,
 			inputsValue: resource.NewPropertyValue(resource.Output{Element: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewObjectProperty(resource.PropertyMap{"key": resource.NewStringProperty("value")}),
+				resource.NewObjectProperty(resource.PropertyMap{keyKey: resource.NewStringProperty(testValue)}),
 			}), Known: true, Secret: true}),
 		},
 		{
 			name:           "secret map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(
+				keyKey: resource.NewObjectProperty(
 					resource.PropertyMap{
-						"key": resource.MakeSecret(resource.NewStringProperty("value")),
+						keyKey: resource.MakeSecret(resource.NewStringProperty(testValue)),
 					},
 				),
 			}),
 		},
 		{
 			name:           "output secret map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(
+				keyKey: resource.NewObjectProperty(
 					resource.PropertyMap{
-						"key": resource.NewPropertyValue(resource.Output{
-							Element: resource.NewStringProperty("value"),
+						keyKey: resource.NewPropertyValue(resource.Output{
+							Element: resource.NewStringProperty(testValue),
 							Known:   true,
 							Secret:  true,
 						}),
@@ -191,59 +210,59 @@ func TestCreateTFFile(t *testing.T) {
 		},
 		{
 			name:           "top level secret map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(resource.PropertyMap{"key": resource.NewStringProperty("")}),
+				keyKey: resource.NewObjectProperty(resource.PropertyMap{keyKey: resource.NewStringProperty("")}),
 			})),
 		},
 		{
 			name:           "top level secret nested map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(resource.PropertyMap{
-					"key": resource.MakeSecret(resource.NewStringProperty("value")),
+				keyKey: resource.NewObjectProperty(resource.PropertyMap{
+					keyKey: resource.MakeSecret(resource.NewStringProperty(testValue)),
 				}),
 			})),
 		},
 		{
 			name:           "top level output secret map(map(any))",
-			tfVariableType: "map(map(any))",
+			tfVariableType: mapMapAnyType,
 			inputsValue: resource.NewPropertyValue(resource.Output{Element: resource.NewObjectProperty(resource.PropertyMap{
-				"key": resource.NewObjectProperty(resource.PropertyMap{"key": resource.NewStringProperty("")}),
+				keyKey: resource.NewObjectProperty(resource.PropertyMap{keyKey: resource.NewStringProperty("")}),
 			}), Known: true, Secret: true}),
 		},
 		{
 			name:           "secret object type",
-			tfVariableType: "object({string_val=string, number_val=number})",
+			tfVariableType: objectStringNumberType,
 			inputsValue: resource.NewObjectProperty(
 				resource.PropertyMap{
-					"string_val": resource.MakeSecret(resource.NewStringProperty("hello")),
-					"number_val": resource.NewNumberProperty(42),
+					stringValKey: resource.MakeSecret(resource.NewStringProperty("hello")),
+					numberValKey: resource.NewNumberProperty(42),
 				},
 			),
 		},
 		{
 			name:           "output secret object type",
-			tfVariableType: "object({string_val=string, number_val=number})",
+			tfVariableType: objectStringNumberType,
 			inputsValue: resource.NewObjectProperty(
 				resource.PropertyMap{
-					"string_val": resource.NewPropertyValue(resource.Output{
+					stringValKey: resource.NewPropertyValue(resource.Output{
 						Element: resource.NewStringProperty("hello"),
 						Known:   true,
 						Secret:  true,
 					}),
-					"number_val": resource.NewNumberProperty(42),
+					numberValKey: resource.NewNumberProperty(42),
 				},
 			),
 		},
 		{
 			name:           "top level secret object type",
-			tfVariableType: "object({string_val=string, number_val=number})",
+			tfVariableType: objectStringNumberType,
 			inputsValue: resource.MakeSecret(
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"string_val": resource.NewStringProperty("hello"),
-						"number_val": resource.NewNumberProperty(42),
+						stringValKey: resource.NewStringProperty("hello"),
+						numberValKey: resource.NewNumberProperty(42),
 					},
 				),
 			),
@@ -291,18 +310,18 @@ func Test_decode(t *testing.T) {
 		{
 			name: "plain values",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewStringProperty("value1"),
-				"key2": resource.NewObjectProperty(resource.PropertyMap{
-					"key3": resource.NewStringProperty("value3"),
+				key1Key: resource.NewStringProperty(value1Val),
+				key2Key: resource.NewObjectProperty(resource.PropertyMap{
+					key3Key: resource.NewStringProperty("value3"),
 				}),
 				"key4": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewStringProperty("value4"),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": "value1",
-				"key2": map[string]interface{}{
-					"key3": "value3",
+				key1Key: value1Val,
+				key2Key: map[string]interface{}{
+					key3Key: "value3",
 				},
 				"key4": []interface{}{
 					"value4",
@@ -312,43 +331,43 @@ func Test_decode(t *testing.T) {
 		{
 			name: "computed value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.MakeComputed(resource.NewStringProperty("")),
+				key1Key: resource.MakeComputed(resource.NewStringProperty("")),
 			},
 			expected: map[string]interface{}{
-				"key1": "${pulumiaux_unk.unknown_proxy.value}",
+				key1Key: unknownProxyValueRef,
 			},
 		},
 		{
 			name: "output unknown value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewOutputProperty(resource.Output{Known: false}),
+				key1Key: resource.NewOutputProperty(resource.Output{Known: false}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${pulumiaux_unk.unknown_proxy.value}",
+				key1Key: unknownProxyValueRef,
 			},
 		},
 		{
 			name: "output known value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewOutputProperty(resource.Output{Known: true, Element: resource.NewStringProperty("value")}),
+				key1Key: resource.NewOutputProperty(resource.Output{Known: true, Element: resource.NewStringProperty(testValue)}),
 			},
 			expected: map[string]interface{}{
-				"key1": "value",
+				key1Key: testValue,
 			},
 		},
 		{
 			name: "nested computed value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.MakeComputed(resource.NewStringProperty("value1")),
+						key2Key: resource.MakeComputed(resource.NewStringProperty(value1Val)),
 					}),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": []interface{}{
+				key1Key: []interface{}{
 					map[string]interface{}{
-						"key2": "${pulumiaux_unk.unknown_proxy.value}",
+						key2Key: unknownProxyValueRef,
 					},
 				},
 			},
@@ -356,18 +375,18 @@ func Test_decode(t *testing.T) {
 		{
 			name: "nested output unknown value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewOutputProperty(resource.Output{Known: true, Element: resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.MakeComputed(resource.NewStringProperty("value1")),
-						"key3": resource.NewOutputProperty(resource.Output{Known: false}),
+						key2Key: resource.MakeComputed(resource.NewStringProperty(value1Val)),
+						key3Key: resource.NewOutputProperty(resource.Output{Known: false}),
 					})}),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": []interface{}{
+				key1Key: []interface{}{
 					map[string]interface{}{
-						"key2": "${pulumiaux_unk.unknown_proxy.value}",
-						"key3": "${pulumiaux_unk.unknown_proxy.value}",
+						key2Key: unknownProxyValueRef,
+						key3Key: unknownProxyValueRef,
 					},
 				},
 			},
@@ -375,56 +394,56 @@ func Test_decode(t *testing.T) {
 		{
 			name: "simple secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewSecretProperty(&resource.Secret{
+				key1Key: resource.NewSecretProperty(&resource.Secret{
 					Element: resource.NewStringProperty("some secret value"),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local1)}",
+				key1Key: sensitiveLocal1Ref,
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "some secret value",
+				local1Key: "some secret value",
 			},
 		},
 		{
 			name: "simple output secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewOutputProperty(resource.Output{
+				key1Key: resource.NewOutputProperty(resource.Output{
 					Element: resource.NewStringProperty("some secret value"),
 					Secret:  true,
 					Known:   true,
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local1)}",
+				key1Key: sensitiveLocal1Ref,
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "some secret value",
+				local1Key: "some secret value",
 			},
 		},
 		{
 			name: "complex secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewSecretProperty(&resource.Secret{
+				key1Key: resource.NewSecretProperty(&resource.Secret{
 					Element: resource.NewArrayProperty([]resource.PropertyValue{
 						resource.NewObjectProperty(resource.PropertyMap{
-							"key": resource.NewObjectProperty(resource.PropertyMap{
-								"nestedKey":  resource.NewStringProperty("value"),
-								"nestedKey2": resource.NewNumberProperty(8),
+							keyKey: resource.NewObjectProperty(resource.PropertyMap{
+								nestedKeyKey:  resource.NewStringProperty(testValue),
+								nestedKey2Key: resource.NewNumberProperty(8),
 							}),
 						}),
 					}),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local1)}",
+				key1Key: sensitiveLocal1Ref,
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": []interface{}{
+				local1Key: []interface{}{
 					map[string]interface{}{
-						"key": map[string]interface{}{
-							"nestedKey":  "value",
-							"nestedKey2": float64(8),
+						keyKey: map[string]interface{}{
+							nestedKeyKey:  testValue,
+							nestedKey2Key: float64(8),
 						},
 					},
 				},
@@ -433,26 +452,26 @@ func Test_decode(t *testing.T) {
 		{
 			name: "complex output secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewOutputProperty(resource.Output{
+				key1Key: resource.NewOutputProperty(resource.Output{
 					Element: resource.NewArrayProperty([]resource.PropertyValue{
 						resource.NewObjectProperty(resource.PropertyMap{
-							"key": resource.NewObjectProperty(resource.PropertyMap{
-								"nestedKey":  resource.NewStringProperty("value"),
-								"nestedKey2": resource.NewNumberProperty(8),
+							keyKey: resource.NewObjectProperty(resource.PropertyMap{
+								nestedKeyKey:  resource.NewStringProperty(testValue),
+								nestedKey2Key: resource.NewNumberProperty(8),
 							}),
 						}),
 					}),
 					Known: true, Secret: true}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local1)}",
+				key1Key: sensitiveLocal1Ref,
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": []interface{}{
+				local1Key: []interface{}{
 					map[string]interface{}{
-						"key": map[string]interface{}{
-							"nestedKey":  "value",
-							"nestedKey2": float64(8),
+						keyKey: map[string]interface{}{
+							nestedKeyKey:  testValue,
+							nestedKey2Key: float64(8),
 						},
 					},
 				},
@@ -461,30 +480,30 @@ func Test_decode(t *testing.T) {
 		{
 			name: "single nested sensitive value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.MakeSecret(resource.NewStringProperty("value1")),
+						key2Key: resource.MakeSecret(resource.NewStringProperty(value1Val)),
 					}),
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": []interface{}{
+				key1Key: []interface{}{
 					map[string]interface{}{
-						"key2": "${sensitive(local.local1)}",
+						key2Key: sensitiveLocal1Ref,
 					},
 				},
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "value1",
+				local1Key: value1Val,
 			},
 		},
 		{
 			name: "single nested output secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.NewPropertyValue(resource.Output{
-							Element: resource.NewStringProperty("value1"),
+						key2Key: resource.NewPropertyValue(resource.Output{
+							Element: resource.NewStringProperty(value1Val),
 							Known:   true,
 							Secret:  true,
 						}),
@@ -492,40 +511,40 @@ func Test_decode(t *testing.T) {
 				}),
 			},
 			expected: map[string]interface{}{
-				"key1": []interface{}{
+				key1Key: []interface{}{
 					map[string]interface{}{
-						"key2": "${sensitive(local.local1)}",
+						key2Key: sensitiveLocal1Ref,
 					},
 				},
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "value1",
+				local1Key: value1Val,
 			},
 		},
 		{
 			name: "top level sensitive with nested sensitive value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.MakeSecret(resource.NewStringProperty("value1")),
+						key2Key: resource.MakeSecret(resource.NewStringProperty(value1Val)),
 					}),
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key3": resource.MakeSecret(resource.NewStringProperty("value2")),
+						key3Key: resource.MakeSecret(resource.NewStringProperty("value2")),
 					}),
 				})),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local3)}",
+				key1Key: "${sensitive(local.local3)}",
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "value1",
-				"local2": "value2",
+				local1Key: value1Val,
+				"local2":  "value2",
 				"local3": []interface{}{
 					map[string]interface{}{
-						"key2": "${sensitive(local.local1)}",
+						key2Key: sensitiveLocal1Ref,
 					},
 					map[string]interface{}{
-						"key3": "${sensitive(local.local2)}",
+						key3Key: "${sensitive(local.local2)}",
 					},
 				},
 			},
@@ -533,27 +552,27 @@ func Test_decode(t *testing.T) {
 		{
 			name: "top level output secret with nested secret value",
 			inputsValue: resource.PropertyMap{
-				"key1": resource.NewPropertyValue(resource.Output{Element: resource.NewArrayProperty([]resource.PropertyValue{
+				key1Key: resource.NewPropertyValue(resource.Output{Element: resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key2": resource.MakeSecret(resource.NewStringProperty("value1")),
+						key2Key: resource.MakeSecret(resource.NewStringProperty(value1Val)),
 					}),
 					resource.NewObjectProperty(resource.PropertyMap{
-						"key3": resource.MakeSecret(resource.NewStringProperty("value2")),
+						key3Key: resource.MakeSecret(resource.NewStringProperty("value2")),
 					}),
 				}), Known: true, Secret: true}),
 			},
 			expected: map[string]interface{}{
-				"key1": "${sensitive(local.local3)}",
+				key1Key: "${sensitive(local.local3)}",
 			},
 			expectedLocals: map[string]interface{}{
-				"local1": "value1",
-				"local2": "value2",
+				local1Key: value1Val,
+				"local2":  "value2",
 				"local3": []interface{}{
 					map[string]interface{}{
-						"key2": "${sensitive(local.local1)}",
+						key2Key: sensitiveLocal1Ref,
 					},
 					map[string]interface{}{
-						"key3": "${sensitive(local.local2)}",
+						key3Key: "${sensitive(local.local2)}",
 					},
 				},
 			},

--- a/pkg/tofuresolver/resolver.go
+++ b/pkg/tofuresolver/resolver.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+const tofuName = "tofu"
+
 // See [Resolve].
 type ResolveOpts struct {
 	// Required version of tofu.
@@ -47,12 +49,12 @@ func findExistingTofu(ctx context.Context, extraPaths []string) (string, bool) {
 	anyVersion := fs.AnyVersion{
 		ExtraPaths: extraPaths,
 		Product: &product.Product{
-			Name: "tofu",
+			Name: tofuName,
 			BinaryName: func() string {
 				if runtime.GOOS == "windows" {
 					return "tofu.exe"
 				}
-				return "tofu"
+				return tofuName
 			},
 		},
 	}
@@ -67,12 +69,12 @@ func tryGetTofuExecutable(ctx context.Context, version *semver.Version) (string,
 	if err != nil {
 		return "", false, fmt.Errorf("could not find pulumi path: %w", err)
 	}
-	installDir := "tofu"
+	installDir := tofuName
 	if version != nil {
 		installDir = fmt.Sprintf("%s-%s", installDir, version.String())
 	}
 	finalDir := filepath.Join(pulumiPath, installDir)
-	binaryPath := filepath.Join(finalDir, "tofu")
+	binaryPath := filepath.Join(finalDir, tofuName)
 	if runtime.GOOS == "windows" {
 		binaryPath += ".exe"
 	}

--- a/tests/acc_test.go
+++ b/tests/acc_test.go
@@ -58,6 +58,19 @@ const (
 	provider                       = "terraform-module"
 	randmod                        = "randmod"
 	useOpentofuEnvironmentVariable = "PULUMI_TERRAFORM_MODULE_USE_OPENTOFU"
+
+	createOp             = "create"
+	deleteOp             = "delete"
+	sameOp               = "same"
+	updateOp             = "update"
+	terraformExec        = "terraform"
+	tofuExec             = "tofu"
+	bucketNamespace      = "bucket"
+	bucketModuleVersion  = "4.5.0"
+	prefixVal            = "PREFIX"
+	testTagKey           = "TestTag"
+	s3BucketMod          = "s3bucketmod"
+	s3BucketModuleSource = "terraform-aws-modules/s3-bucket/aws"
 )
 
 // testdata/randmod is a fully local module written for test purposes that uses resources from the
@@ -106,7 +119,7 @@ func Test_RandMod_TypeScript(t *testing.T) {
 			optpreview.ErrorProgressStreams(tw),
 		)
 		assert.Equal(t, map[apitype.OpType]int{
-			apitype.OpType("create"): 4,
+			apitype.OpType(createOp): 4,
 		}, previewResult.ChangeSummary)
 	})
 
@@ -122,7 +135,7 @@ func Test_RandMod_TypeScript(t *testing.T) {
 		t.Logf("%s", upResult.StdOut+upResult.StdErr)
 
 		assert.Equal(t, &map[string]int{
-			"create": 4,
+			createOp: 4,
 		}, upResult.Summary.ResourceChanges)
 
 		outputs, err := pt.CurrentStack().Outputs(context.Background())
@@ -157,14 +170,14 @@ func Test_RandMod_TypeScript(t *testing.T) {
 	t.Run("pulumi preview should be empty", func(t *testing.T) {
 		previewResult := pt.Preview(t)
 		t.Logf("%s", previewResult.StdOut+previewResult.StdErr)
-		assert.Equal(t, map[apitype.OpType]int{apitype.OpType("same"): 4},
+		assert.Equal(t, map[apitype.OpType]int{apitype.OpType(sameOp): 4},
 			previewResult.ChangeSummary)
 	})
 
 	t.Run("pulumi up should be no-op", func(t *testing.T) {
 		upResult := pt.Up(t)
 		t.Logf("%s", upResult.StdOut+upResult.StdErr)
-		assert.Equal(t, &map[string]int{"same": 4}, upResult.Summary.ResourceChanges)
+		assert.Equal(t, &map[string]int{sameOp: 4}, upResult.Summary.ResourceChanges)
 	})
 
 	t.Run("pulumi destroy", func(t *testing.T) {
@@ -313,9 +326,9 @@ func TestPartialApply(t *testing.T) {
 	)
 	changes2 := *upRes2.Summary.ResourceChanges
 	assert.Equal(t, map[string]int{
-		"update": 2,
-		"create": 1,
-		"same":   1,
+		updateOp: 2,
+		createOp: 1,
+		sameOp:   1,
 	}, changes2)
 	assert.Contains(t, upRes2.Outputs, "roleArn")
 
@@ -353,9 +366,9 @@ func TestPartialApply(t *testing.T) {
 	)
 	changes4 := *upRes4.Summary.ResourceChanges
 	assert.Equal(t, map[string]int{
-		"update": 2,
-		"create": 1,
-		"same":   1,
+		updateOp: 2,
+		createOp: 1,
+		sameOp:   1,
 	}, changes4)
 	assert.Contains(t, upRes4.Outputs, "roleArn")
 
@@ -391,14 +404,14 @@ func Test_TwoInstances_TypeScript(t *testing.T) {
 		previewResult := pt.Preview(t, optpreview.Diff())
 		t.Logf("%s", previewResult.StdOut+previewResult.StdErr)
 		assert.Equal(t, map[apitype.OpType]int{
-			apitype.OpType("create"): 5,
+			apitype.OpType(createOp): 5,
 		}, previewResult.ChangeSummary)
 	})
 
 	t.Run("pulumi up", func(t *testing.T) {
 		upResult := pt.Up(t)
 		t.Logf("%s", upResult.StdOut+upResult.StdErr)
-		assert.Equal(t, &map[string]int{"create": 5}, upResult.Summary.ResourceChanges)
+		assert.Equal(t, &map[string]int{createOp: 5}, upResult.Summary.ResourceChanges)
 	})
 }
 
@@ -424,10 +437,10 @@ func TestAutomaticallySettingNameInputFromResourceName(t *testing.T) {
 	assert.True(t, ok, "expected output value to be a string")
 	assert.True(t, strings.HasPrefix(resultValue, "exampleResourceName-"))
 	preview := integrationTest.Preview(t)
-	assert.Equal(t, 2, preview.ChangeSummary[apitype.OpType("same")])
+	assert.Equal(t, 2, preview.ChangeSummary[apitype.OpType(sameOp)])
 
 	deleteResult := integrationTest.Destroy(t)
-	expected := &map[string]int{"delete": 2}
+	expected := &map[string]int{deleteOp: 2}
 	assert.Equal(t, deleteResult.Summary.ResourceChanges, expected, "should delete one resource")
 }
 
@@ -464,11 +477,13 @@ func TestChangingLocalModuleSourceCodeOutputsCausesUpdate(t *testing.T) {
 	v2SourceCode, err := os.ReadFile(filepath.Join(v2, "main.tf"))
 	require.NoError(t, err, "failed to read v2 source code")
 
+	//nolint:gosec // G703: v1 is a test-controlled temp module directory, not attacker input
 	err = os.WriteFile(filepath.Join(v1, "main.tf"), v2SourceCode, 0600)
 	require.NoError(t, err, "failed to write v2 source code to v1 module")
 
 	t.Cleanup(func() {
 		// Restore the original source code after the test
+		//nolint:gosec // G703: v1 is a test-controlled temp module directory, not attacker input
 		err := os.WriteFile(filepath.Join(v1, "main.tf"), v1SourceCode, 0600)
 		require.NoError(t, err, "failed to restore v1 source code")
 	})
@@ -511,19 +526,21 @@ func TestChangingLocalModuleSourceCodeResourcesCausesUpdate(t *testing.T) {
 	v2SourceCode, err := os.ReadFile(filepath.Join(v2, "main.tf"))
 	require.NoError(t, err, "failed to read v2 source code")
 
+	//nolint:gosec // G703: v1 is a test-controlled temp module directory, not attacker input
 	err = os.WriteFile(filepath.Join(v1, "main.tf"), v2SourceCode, 0600)
 	require.NoError(t, err, "failed to write v2 source code to v1 module")
 
 	t.Cleanup(func() {
 		// Restore the original source code after the test
+		//nolint:gosec // G703: v1 is a test-controlled temp module directory, not attacker input
 		err := os.WriteFile(filepath.Join(v1, "main.tf"), v1SourceCode, 0600)
 		require.NoError(t, err, "failed to restore v1 source code")
 	})
 
 	preview := integrationTest.Preview(t)
-	assert.Equal(t, 1, preview.ChangeSummary[apitype.OpType("delete")],
+	assert.Equal(t, 1, preview.ChangeSummary[apitype.OpType(deleteOp)],
 		"expected one resource to be deleted")
-	assert.Equal(t, 1, preview.ChangeSummary[apitype.OpType("create")],
+	assert.Equal(t, 1, preview.ChangeSummary[apitype.OpType(createOp)],
 		"expected one resource to be created")
 
 	integrationTest.Up(t)
@@ -606,7 +623,7 @@ func TestTerraformAwsModulesVpcIntoTypeScript(t *testing.T) {
 		pulumiConvert(t, localProviderBinPath, pclDir, testDir, "typescript", generateOnly)
 	})
 
-	for _, executor := range []string{"terraform", "tofu"} {
+	for _, executor := range []string{terraformExec, tofuExec} {
 		t.Run(fmt.Sprintf("executor=%s", executor), func(t *testing.T) {
 			pt := newPulumiTest(t, testDir,
 				opttest.LocalProviderPath(provider, filepath.Dir(localProviderBinPath)),
@@ -629,7 +646,7 @@ func TestTerraformAwsModulesVpcIntoTypeScript(t *testing.T) {
 				expectedResourceCount := 6
 
 				require.Equal(t, res.Summary.ResourceChanges, &map[string]int{
-					"create": expectedResourceCount,
+					createOp: expectedResourceCount,
 				})
 
 				tfStateRaw := mustFindRawState(t, pt, "vpc")
@@ -653,10 +670,10 @@ func TestS3BucketModSecret(t *testing.T) {
 	// t.Parallel() - cannot use t.Parallel because the test uses SetEnv
 	localProviderBinPath := ensureCompiledProvider(t)
 	skipLocalRunsWithoutCreds(t)
-	testProgram := filepath.Join("testdata", "programs", "ts", "s3bucketmod")
+	testProgram := filepath.Join("testdata", "programs", "ts", s3BucketMod)
 	localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
 
-	for _, executor := range []string{"terraform", "tofu"} {
+	for _, executor := range []string{terraformExec, tofuExec} {
 		t.Run(fmt.Sprintf("executor=%s", executor), func(t *testing.T) {
 
 			integrationTest := newPulumiTest(t, testProgram, localPath,
@@ -670,7 +687,7 @@ func TestS3BucketModSecret(t *testing.T) {
 
 			// Generate package
 			//nolint:all
-			pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/s3-bucket/aws", "4.5.0", "bucket")
+			pulumiPackageAdd(t, integrationTest, localProviderBinPath, s3BucketModuleSource, bucketModuleVersion, bucketNamespace)
 			integrationTest.Up(t)
 
 			encrConf := mustFindDeploymentResourceByType(t,
@@ -694,7 +711,7 @@ func TestShowingModifiedAWSCredentialsError(t *testing.T) {
 	skipLocalRunsWithoutCreds(t)
 	localProviderBinPath := ensureCompiledProvider(t)
 
-	testProgram := filepath.Join("testdata", "programs", "ts", "s3bucketmod")
+	testProgram := filepath.Join("testdata", "programs", "ts", s3BucketMod)
 	localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
 
 	// disable AWS credentials to test the error message shows up
@@ -712,7 +729,7 @@ func TestShowingModifiedAWSCredentialsError(t *testing.T) {
 
 	// Generate package
 	//nolint:all
-	pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/s3-bucket/aws", "4.5.0", "bucket")
+	pulumiPackageAdd(t, integrationTest, localProviderBinPath, s3BucketModuleSource, bucketModuleVersion, bucketNamespace)
 	_, err := integrationTest.CurrentStack().Up(context.Background())
 	assert.Error(t, err)
 	// assert that error contains part of the modified credentials error message which is Pulumi sepcific
@@ -728,6 +745,7 @@ func cleanRandomDataFromTerraformArtifacts(t *testing.T, tfFilesDir string, repl
 			return err
 		}
 		if !info.IsDir() {
+			//nolint:gosec // G122: walk over a test-controlled fixture directory, no untrusted symlinks
 			b, err := os.ReadFile(path)
 			if err != nil {
 				return err
@@ -737,6 +755,7 @@ func cleanRandomDataFromTerraformArtifacts(t *testing.T, tfFilesDir string, repl
 				s = strings.ReplaceAll(s, data, replace)
 			}
 
+			//nolint:gosec // G122: walk over a test-controlled fixture directory, no untrusted symlinks
 			err = os.WriteFile(path, []byte(s), 0o600)
 			if err != nil {
 				return err
@@ -762,7 +781,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 		return fullPath
 	}
 
-	for _, executor := range []string{"terraform", "tofu"} {
+	for _, executor := range []string{terraformExec, tofuExec} {
 		t.Run(fmt.Sprintf("executor=%s", executor), func(t *testing.T) {
 
 			integrationTest := newPulumiTest(t, testProgram,
@@ -778,7 +797,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 
 			// Generate package
 			//nolint:all
-			pulumiPackageAdd(t, integrationTest, localProviderBinPath, "terraform-aws-modules/s3-bucket/aws", "4.5.0", "bucket")
+			pulumiPackageAdd(t, integrationTest, localProviderBinPath, s3BucketModuleSource, bucketModuleVersion, bucketNamespace)
 
 			t.Run("pulumi preview", func(t *testing.T) {
 				tfFiles := tfFilesDir("preview")
@@ -786,7 +805,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 				preview := integrationTest.Preview(t)
 				require.Empty(t, preview.StdErr, "expected no errors in preview")
 				cleanRandomDataFromTerraformArtifacts(t, tfFiles, map[string]string{
-					prefix: "PREFIX",
+					prefix: prefixVal,
 				})
 			})
 
@@ -796,7 +815,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 				up := integrationTest.Up(t)
 				require.Empty(t, up.StdErr, "expected no errors in up")
 				cleanRandomDataFromTerraformArtifacts(t, tfFiles, map[string]string{
-					prefix: "PREFIX",
+					prefix: prefixVal,
 				})
 			})
 
@@ -806,7 +825,7 @@ func TestS3BucketWithExplicitProvider(t *testing.T) {
 				destroy := integrationTest.Destroy(t)
 				require.Empty(t, destroy.StdErr, "expected no errors in destroy")
 				cleanRandomDataFromTerraformArtifacts(t, tfFiles, map[string]string{
-					prefix: "PREFIX",
+					prefix: prefixVal,
 				})
 			})
 		})
@@ -831,15 +850,15 @@ func TestE2eTs(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:            "s3bucketmod",
-			moduleName:      "terraform-aws-modules/s3-bucket/aws",
-			moduleVersion:   "4.5.0",
-			moduleNamespace: "bucket",
-			previewExpect:   autogold.Expect(map[apitype.OpType]int{apitype.OpType("create"): 5}),
-			upExpect:        autogold.Expect(&map[string]int{"create": 5}),
-			deleteExpect:    autogold.Expect(&map[string]int{"delete": 5}),
+			name:            s3BucketMod,
+			moduleName:      s3BucketModuleSource,
+			moduleVersion:   bucketModuleVersion,
+			moduleNamespace: bucketNamespace,
+			previewExpect:   autogold.Expect(map[apitype.OpType]int{apitype.OpType(createOp): 5}),
+			upExpect:        autogold.Expect(&map[string]int{createOp: 5}),
+			deleteExpect:    autogold.Expect(&map[string]int{deleteOp: 5}),
 			diffNoChangesExpect: autogold.Expect(map[apitype.OpType]int{
-				apitype.OpType("same"): 5,
+				apitype.OpType(sameOp): 5,
 			}),
 		},
 		{
@@ -850,13 +869,13 @@ func TestE2eTs(t *testing.T) {
 			// aws lambda module creates drift even in terraform
 			skipNoChangesExpect: true,
 			previewExpect: autogold.Expect(map[apitype.OpType]int{
-				apitype.OpType("create"): 8,
+				apitype.OpType(createOp): 8,
 			}),
 			upExpect: autogold.Expect(&map[string]int{
-				"create": 8,
+				createOp: 8,
 			}),
 			deleteExpect: autogold.Expect(&map[string]int{
-				"delete": 8,
+				deleteOp: 8,
 			}),
 			// With Views drift detection does not quite get picked up yet.
 			// TODO[pulumi/pulumi#19487] and opt into this behavior for the Module. This
@@ -864,7 +883,7 @@ func TestE2eTs(t *testing.T) {
 			// the final counts match or not is less important, the user expectation is to
 			// refresh by default as TF does.
 			diffNoChangesExpect: autogold.Expect(map[apitype.OpType]int{
-				apitype.OpType("same"): 8,
+				apitype.OpType(sameOp): 8,
 			}),
 		},
 		{
@@ -876,16 +895,16 @@ func TestE2eTs(t *testing.T) {
 			// so we need to refresh to get the correct preview
 			previewRefresh: true,
 			previewExpect: autogold.Expect(map[apitype.OpType]int{
-				apitype.OpType("create"): 10,
+				apitype.OpType(createOp): 10,
 			}),
 			upExpect: autogold.Expect(&map[string]int{
-				"create": 10,
+				createOp: 10,
 			}),
 			deleteExpect: autogold.Expect(&map[string]int{
-				"delete": 10,
+				deleteOp: 10,
 			}),
 			diffNoChangesExpect: autogold.Expect(map[apitype.OpType]int{
-				apitype.OpType("same"): 10,
+				apitype.OpType(sameOp): 10,
 			}),
 		},
 	}
@@ -958,21 +977,21 @@ func TestE2eDotnet(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:            "s3bucketmod",
-			moduleName:      "terraform-aws-modules/s3-bucket/aws",
-			moduleVersion:   "4.5.0",
-			moduleNamespace: "bucket",
+			name:            s3BucketMod,
+			moduleName:      s3BucketModuleSource,
+			moduleVersion:   bucketModuleVersion,
+			moduleNamespace: bucketNamespace,
 			previewExpect: map[apitype.OpType]int{
-				apitype.OpType("create"): 4,
+				apitype.OpType(createOp): 4,
 			},
 			upExpect: &map[string]int{
-				"create": 4,
+				createOp: 4,
 			},
 			deleteExpect: &map[string]int{
-				"delete": 4,
+				deleteOp: 4,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 4,
+				apitype.OpType(sameOp): 4,
 			},
 		},
 	}
@@ -1036,21 +1055,21 @@ func TestE2ePython(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:            "s3bucketmod",
-			moduleName:      "terraform-aws-modules/s3-bucket/aws",
-			moduleVersion:   "4.5.0",
-			moduleNamespace: "bucket",
+			name:            s3BucketMod,
+			moduleName:      s3BucketModuleSource,
+			moduleVersion:   bucketModuleVersion,
+			moduleNamespace: bucketNamespace,
 			previewExpect: map[apitype.OpType]int{
-				apitype.OpType("create"): 4,
+				apitype.OpType(createOp): 4,
 			},
 			upExpect: &map[string]int{
-				"create": 4,
+				createOp: 4,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 4,
+				apitype.OpType(sameOp): 4,
 			},
 			deleteExpect: &map[string]int{
-				"delete": 4,
+				deleteOp: 4,
 			},
 		},
 	}
@@ -1117,21 +1136,21 @@ func TestE2eGo(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:            "s3bucketmod",
-			moduleName:      "terraform-aws-modules/s3-bucket/aws",
-			moduleVersion:   "4.5.0",
-			moduleNamespace: "bucket",
+			name:            s3BucketMod,
+			moduleName:      s3BucketModuleSource,
+			moduleVersion:   bucketModuleVersion,
+			moduleNamespace: bucketNamespace,
 			previewExpect: map[apitype.OpType]int{
-				apitype.OpType("create"): 4,
+				apitype.OpType(createOp): 4,
 			},
 			upExpect: &map[string]int{
-				"create": 4,
+				createOp: 4,
 			},
 			deleteExpect: &map[string]int{
-				"delete": 4,
+				deleteOp: 4,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 4,
+				apitype.OpType(sameOp): 4,
 			},
 		},
 	}
@@ -1194,21 +1213,21 @@ func TestE2eYAML(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:            "s3bucketmod",
-			moduleName:      "terraform-aws-modules/s3-bucket/aws",
-			moduleVersion:   "4.5.0",
-			moduleNamespace: "bucket",
+			name:            s3BucketMod,
+			moduleName:      s3BucketModuleSource,
+			moduleVersion:   bucketModuleVersion,
+			moduleNamespace: bucketNamespace,
 			previewExpect: map[apitype.OpType]int{
-				apitype.OpType("create"): 4,
+				apitype.OpType(createOp): 4,
 			},
 			upExpect: &map[string]int{
-				"create": 4,
+				createOp: 4,
 			},
 			deleteExpect: &map[string]int{
-				"delete": 4,
+				deleteOp: 4,
 			},
 			diffNoChangesExpect: map[apitype.OpType]int{
-				apitype.OpType("same"): 4,
+				apitype.OpType(sameOp): 4,
 			},
 		},
 	}
@@ -1258,10 +1277,10 @@ func TestE2eYAML(t *testing.T) {
 func TestModuleUpgrade(t *testing.T) {
 	t.Parallel()
 
-	name := "s3bucketmod"
-	moduleName := "terraform-aws-modules/s3-bucket/aws"
-	moduleVersion := "4.5.0"
-	moduleNamespace := "bucket"
+	name := s3BucketMod
+	moduleName := s3BucketModuleSource
+	moduleVersion := bucketModuleVersion
+	moduleNamespace := bucketNamespace
 
 	localProviderBinPath := ensureCompiledProvider(t)
 	skipLocalRunsWithoutCreds(t)
@@ -1329,7 +1348,7 @@ func TestDiffDetailTerraform(t *testing.T) {
 	// Set up a test Bucket
 	localProviderBinPath := ensureCompiledProvider(t)
 	skipLocalRunsWithoutCreds(t)
-	testProgram := filepath.Join("testdata", "programs", "ts", "s3bucketmod")
+	testProgram := filepath.Join("testdata", "programs", "ts", s3BucketMod)
 	localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
 
 	diffDetailTest := newPulumiTest(t, testProgram, localPath)
@@ -1342,13 +1361,13 @@ func TestDiffDetailTerraform(t *testing.T) {
 
 	// Generate package
 	//nolint:lll
-	pulumiPackageAdd(t, diffDetailTest, localProviderBinPath, "terraform-aws-modules/s3-bucket/aws", "4.5.0", "bucket")
+	pulumiPackageAdd(t, diffDetailTest, localProviderBinPath, s3BucketModuleSource, bucketModuleVersion, bucketNamespace)
 
 	// Up
 	diffDetailTest.Up(t)
 
 	// Change program to remove the module input `server_side_encryption_configuration`
-	diffDetailTest.UpdateSource(t, filepath.Join("testdata", "programs", "ts", "s3bucketmod", "updates"))
+	diffDetailTest.UpdateSource(t, filepath.Join("testdata", "programs", "ts", s3BucketMod, "updates"))
 
 	// Preview
 	var debugOpts debug.LoggingOptions
@@ -1369,9 +1388,9 @@ func TestDiffDetailTerraform(t *testing.T) {
 		optpreview.DebugLogging(debugOpts))
 
 	assert.Equal(t, map[apitype.OpType]int{
-		apitype.OpType("delete"): 1,
-		apitype.OpType("same"):   3,
-		apitype.OpType("update"): 1,
+		apitype.OpType(deleteOp): 1,
+		apitype.OpType(sameOp):   3,
+		apitype.OpType(updateOp): 1,
 	}, result.ChangeSummary)
 
 	// Expected CLI to render a diff on removing server_side_encryption_configuration input from the module.
@@ -1387,11 +1406,11 @@ func TestDiffDetailOpenTofu(t *testing.T) {
 	// Set up a test Bucket
 	localProviderBinPath := ensureCompiledProvider(t)
 
-	testProgram := filepath.Join("testdata", "programs", "ts", "s3bucketmod")
+	testProgram := filepath.Join("testdata", "programs", "ts", s3BucketMod)
 	localPath := opttest.LocalProviderPath("terraform-module", filepath.Dir(localProviderBinPath))
 
 	diffDetailTest := pulumitest.NewPulumiTest(t, testProgram, localPath,
-		opttest.Env("PULUMI_TERRAFORM_MODULE_EXECUTOR", "tofu"))
+		opttest.Env("PULUMI_TERRAFORM_MODULE_EXECUTOR", tofuExec))
 
 	// Get a prefix for resource names
 	prefix := generateTestResourcePrefix()
@@ -1401,13 +1420,13 @@ func TestDiffDetailOpenTofu(t *testing.T) {
 
 	// Generate package
 	//nolint:lll
-	pulumiPackageAdd(t, diffDetailTest, localProviderBinPath, "terraform-aws-modules/s3-bucket/aws", "4.5.0", "bucket")
+	pulumiPackageAdd(t, diffDetailTest, localProviderBinPath, s3BucketModuleSource, bucketModuleVersion, bucketNamespace)
 
 	// Up
 	diffDetailTest.Up(t)
 
 	// Change program to remove the module input `server_side_encryption_configuration`
-	diffDetailTest.UpdateSource(t, filepath.Join("testdata", "programs", "ts", "s3bucketmod", "updates"))
+	diffDetailTest.UpdateSource(t, filepath.Join("testdata", "programs", "ts", s3BucketMod, "updates"))
 
 	// Preview
 	var debugOpts debug.LoggingOptions
@@ -1428,9 +1447,9 @@ func TestDiffDetailOpenTofu(t *testing.T) {
 		optpreview.DebugLogging(debugOpts))
 
 	assert.Equal(t, map[apitype.OpType]int{
-		apitype.OpType("delete"): 1,
-		apitype.OpType("same"):   3,
-		apitype.OpType("update"): 1,
+		apitype.OpType(deleteOp): 1,
+		apitype.OpType(sameOp):   3,
+		apitype.OpType(updateOp): 1,
 	}, result.ChangeSummary)
 
 	// Expected CLI to render a diff on removing server_side_encryption_configuration input from the module.
@@ -1466,7 +1485,7 @@ func checkRefresh(t *testing.T, executor string) {
 	expectBucketTag := func(tagvalue string) {
 		bucket := mustFindDeploymentResourceByType(t, it, "bucketmod:tf:aws_s3_bucket")
 		tags := bucket.Inputs["tags"]
-		require.Equal(t, map[string]any{"TestTag": tagvalue}, tags)
+		require.Equal(t, map[string]any{testTagKey: tagvalue}, tags)
 	}
 
 	pulumiPackageAdd(t, it, localBin, testMod, "bucketmod")
@@ -1483,7 +1502,7 @@ func checkRefresh(t *testing.T, executor string) {
 	it.Up(t, optup.ErrorProgressStreams(tw), optup.ProgressStreams(tw))
 	outMapB, err := it.CurrentStack().Outputs(ctx)
 	require.NoError(t, err)
-	autogold.Expect(map[string]any{"TestTag": "b"}).Equal(t, outMapB["tags"].Value)
+	autogold.Expect(map[string]any{testTagKey: "b"}).Equal(t, outMapB["tags"].Value)
 
 	t.Logf("# pulumi stack import --file state-a.json to reset to initial state")
 	it.ImportStack(t, stateA)
@@ -1507,7 +1526,7 @@ func checkRefresh(t *testing.T, executor string) {
 		optrefresh.ProgressStreams(tw),
 	)
 	rc := refreshResult.Summary.ResourceChanges
-	autogold.Expect(&map[string]int{"same": 1, "update": 2}).Equal(t, rc)
+	autogold.Expect(&map[string]int{sameOp: 1, updateOp: 2}).Equal(t, rc)
 
 	// Check that in the state the bucket has TestTag="b" now as refresh took effect.
 	expectBucketTag("b")
@@ -1518,7 +1537,7 @@ func checkRefresh(t *testing.T, executor string) {
 	// TODO[github.com/pulumi/pulumi#2710] Refresh does not update stack outputs
 	outMap, err := it.CurrentStack().Outputs(ctx)
 	require.NoError(t, err)
-	autogold.Expect(map[string]any{"TestTag": "a"}).Equal(t, outMap["tags"].Value)
+	autogold.Expect(map[string]any{testTagKey: "a"}).Equal(t, outMap["tags"].Value)
 }
 
 func TestRefreshTerraform(t *testing.T) {
@@ -1526,7 +1545,7 @@ func TestRefreshTerraform(t *testing.T) {
 }
 
 func TestRefreshTofu(t *testing.T) {
-	checkRefresh(t, "tofu")
+	checkRefresh(t, tofuExec)
 }
 
 // This variation of TestRefresh checks that normal pulumi preview and pulumi up detect and correct drift even when
@@ -1555,13 +1574,13 @@ func checkRefreshImplicitly(t *testing.T, executor string) {
 	expectBucketTag := func(tagvalue string) {
 		bucket := mustFindDeploymentResourceByType(t, it, "bucketmod:tf:aws_s3_bucket")
 		tags := bucket.Inputs["tags"]
-		assert.Equalf(t, map[string]any{"TestTag": tagvalue}, tags, "incorrect Pulumi bucket view-state")
+		assert.Equalf(t, map[string]any{testTagKey: tagvalue}, tags, "incorrect Pulumi bucket view-state")
 
 		addr := "module.mybucketmod.aws_s3_bucket.tf-test-bucket"
 		raw := assertTFStateResourceExists(t, it, "bucketmod", addr)
 		instance := raw.(map[string]any)["instances"].([]any)[0].(map[string]any)
 		tfTags := instance["attributes"].(map[string]any)["tags"]
-		assert.Equal(t, map[string]any{"TestTag": tagvalue}, tfTags, "incorrect Terraform bucket state")
+		assert.Equal(t, map[string]any{testTagKey: tagvalue}, tfTags, "incorrect Terraform bucket state")
 	}
 
 	pulumiPackageAdd(t, it, localBin, testMod, "bucketmod")
@@ -1610,7 +1629,7 @@ func checkRefreshImplicitly(t *testing.T, executor string) {
 	expectBucketTag("a")
 
 	//nolint:lll
-	autogold.Expect(map[apitype.OpType]int{apitype.OpType("same"): 1, apitype.OpType("update"): 2}).Equal(t, previewResult.ChangeSummary)
+	autogold.Expect(map[apitype.OpType]int{apitype.OpType(sameOp): 1, apitype.OpType(updateOp): 2}).Equal(t, previewResult.ChangeSummary)
 
 	t.Logf("## pulumi up: expect to detect the drift and correct it")
 	upResult := it.Up(t,
@@ -1620,7 +1639,7 @@ func checkRefreshImplicitly(t *testing.T, executor string) {
 		optup.DebugLogging(debugOpts),
 	)
 
-	autogold.Expect(&map[string]int{"same": 1, "update": 2}).Equal(t, upResult.Summary.ResourceChanges)
+	autogold.Expect(&map[string]int{sameOp: 1, updateOp: 2}).Equal(t, upResult.Summary.ResourceChanges)
 
 	// The state of the bucket should indicate "a" since it was reconciled to the desired state.
 	expectBucketTag("a")
@@ -1631,7 +1650,7 @@ func TestRefreshImplicitlyTerraform(t *testing.T) {
 }
 
 func TestRefreshImplicitlyTofu(t *testing.T) {
-	checkRefreshImplicitly(t, "tofu")
+	checkRefreshImplicitly(t, tofuExec)
 }
 
 // Verify that pulumi refresh detects deleted resources.
@@ -1679,7 +1698,7 @@ func checkRefreshDeleted(t *testing.T, executor string) {
 	)
 
 	rc := refreshResult.Summary.ResourceChanges
-	autogold.Expect(&map[string]int{"delete": 1, "same": 1, "update": 1}).Equal(t, rc)
+	autogold.Expect(&map[string]int{deleteOp: 1, sameOp: 1, updateOp: 1}).Equal(t, rc)
 
 	// Check that the bucket view-state is removed from the statefile.
 	stateR := it.ExportStack(t)
@@ -1702,7 +1721,7 @@ func TestRefreshDeletedTerraform(t *testing.T) {
 }
 
 func TestRefreshDeletedTofu(t *testing.T) {
-	checkRefreshDeleted(t, "tofu")
+	checkRefreshDeleted(t, tofuExec)
 }
 
 // Verify that when there is no drift, refresh works without any changes.
@@ -1755,7 +1774,7 @@ func checkRefreshNoChanges(t *testing.T, executor string) {
 
 	rc := refreshResult.Summary.ResourceChanges
 	assert.Equal(t, &map[string]int{
-		"same": 3,
+		sameOp: 3,
 	}, rc)
 }
 
@@ -1764,7 +1783,7 @@ func TestRefreshNoChangesTerraform(t *testing.T) {
 }
 
 func TestRefreshNoChangesTofu(t *testing.T) {
-	checkRefreshNoChanges(t, "tofu")
+	checkRefreshNoChanges(t, tofuExec)
 }
 
 // Verify that pulumi destroy actually removes cloud resources, using Lambda module as the example
@@ -1988,7 +2007,7 @@ func Test_LocalModule_RelativePath_OpenTofu(t *testing.T) {
 	localPath := opttest.LocalProviderPath(provider, filepath.Dir(localProviderBinPath))
 
 	pt := newPulumiTest(t, anyProgram, localPath,
-		opttest.Env("PULUMI_TERRAFORM_MODULE_EXECUTOR", "tofu"))
+		opttest.Env("PULUMI_TERRAFORM_MODULE_EXECUTOR", tofuExec))
 	pt.CopyToTempDir(t)
 
 	err = os.CopyFS(filepath.Join(pt.WorkingDir(), "randmod"), os.DirFS(randMod))

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -189,7 +189,7 @@ func Test_AlbExample(t *testing.T) {
 	)
 
 	assert.Equal(t, &map[string]int{
-		"create": 46,
+		createOp: 46,
 	}, upResult.Summary.ResourceChanges)
 
 	integrationTest.Preview(t,

--- a/tests/replace_test.go
+++ b/tests/replace_test.go
@@ -88,8 +88,8 @@ func Test_replace_forcenew_delete_create(t *testing.T) {
 
 	assert.Equal(t, map[apitype.OpType]int{
 		apitype.OpType("replace"): 1,
-		apitype.OpType("same"):    1,
-		apitype.OpType("update"):  1,
+		apitype.OpType(sameOp):    1,
+		apitype.OpType(updateOp):  1,
 	}, diffResult.ChangeSummary)
 
 	replaceResult := pt.Up(t,
@@ -99,8 +99,8 @@ func Test_replace_forcenew_delete_create(t *testing.T) {
 
 	assert.Equal(t, &map[string]int{
 		"replace": 1,
-		"same":    1,
-		"update":  1,
+		sameOp:    1,
+		updateOp:  1,
 	}, replaceResult.Summary.ResourceChanges)
 }
 
@@ -152,8 +152,8 @@ func Test_replace_forcenew_create_delete(t *testing.T) {
 
 	assert.Equal(t, map[apitype.OpType]int{
 		apitype.OpType("replace"): 1,
-		apitype.OpType("same"):    1,
-		apitype.OpType("update"):  1,
+		apitype.OpType(sameOp):    1,
+		apitype.OpType(updateOp):  1,
 	}, diffResult.ChangeSummary)
 
 	upResult := pt.Up(t,
@@ -165,8 +165,8 @@ func Test_replace_forcenew_create_delete(t *testing.T) {
 
 	assert.Equal(t, &map[string]int{
 		"replace": 1,
-		"same":    1,
-		"update":  1,
+		sameOp:    1,
+		updateOp:  1,
 	}, upResult.Summary.ResourceChanges)
 }
 
@@ -219,8 +219,8 @@ func Test_replace_trigger_delete_create(t *testing.T) {
 
 	assert.Equal(t, map[apitype.OpType]int{
 		apitype.OpType("replace"): 2,
-		apitype.OpType("same"):    1,
-		apitype.OpType("update"):  1,
+		apitype.OpType(sameOp):    1,
+		apitype.OpType(updateOp):  1,
 	}, diffResult.ChangeSummary)
 
 	// Although it is unclear which Pulumi-modeled input caused a replacement, assert that the plan is still a
@@ -309,9 +309,9 @@ func Test_replace_drift_deleted(t *testing.T) {
 	assertTFStateResourceExists(t, pt, packageName, "module.rmod.local_file.hello")
 
 	autogold.Expect(map[apitype.OpType]int{
-		apitype.OpType("create"): 1,
-		apitype.OpType("same"):   1,
-		apitype.OpType("update"): 1,
+		apitype.OpType(createOp): 1,
+		apitype.OpType(sameOp):   1,
+		apitype.OpType(updateOp): 1,
 	}).Equal(t, previewResult.ChangeSummary)
 
 	t.Logf("## pulumi up: fix the drift by re-creating the missing resource")
@@ -330,9 +330,9 @@ func Test_replace_drift_deleted(t *testing.T) {
 	}
 
 	autogold.Expect(&map[string]int{
-		"create": 1,
-		"same":   1,
-		"update": 1,
+		createOp: 1,
+		sameOp:   1,
+		updateOp: 1,
 	}).Equal(t, upResult.Summary.ResourceChanges)
 
 	// The resource representing the file should exist in TF state as well.

--- a/tests/schema_create_secrets_test.go
+++ b/tests/schema_create_secrets_test.go
@@ -87,17 +87,17 @@ resource "aws_s3_bucket" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"expiration": []interface{}{}, "noncurrent_version_expiration": []interface{}{},
-						"noncurrent_version_transition": []interface{}{},
-						"prefix":                        true,
-						"transition":                    []interface{}{},
+						expirationKey: []interface{}{}, noncurrentVersionExpirationKey: []interface{}{},
+						noncurrentVersionTransitionKey: []interface{}{},
+						prefixKey:                      true,
+						transitionKey:                  []interface{}{},
 					},
 					map[string]interface{}{
-						"expiration":                    []interface{}{},
-						"noncurrent_version_expiration": []interface{}{},
-						"noncurrent_version_transition": []interface{}{},
-						"transition":                    []interface{}{},
-						"id":                            true,
+						expirationKey:                  []interface{}{},
+						noncurrentVersionExpirationKey: []interface{}{},
+						noncurrentVersionTransitionKey: []interface{}{},
+						transitionKey:                  []interface{}{},
+						"id":                           true,
 					},
 				}).Equal(t, actual)
 			})
@@ -142,16 +142,16 @@ resource "aws_s3_bucket" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"id":          "value",
-						"permissions": []interface{}{"FULL_CONTROL"},
-						"type":        "CanonicalUser",
-						"uri":         "",
+						"id":           "value",
+						permissionsKey: []interface{}{fullControlPermission},
+						typeKey:        canonicalUserType,
+						uriKey:         "",
 					},
 					map[string]interface{}{
-						"id":          "value1",
-						"permissions": []interface{}{"FULL_CONTROL"},
-						"type":        "CanonicalUser",
-						"uri":         "",
+						"id":           "value1",
+						permissionsKey: []interface{}{fullControlPermission},
+						typeKey:        canonicalUserType,
+						uriKey:         "",
 					},
 				}).Equal(t, actual)
 			},
@@ -198,12 +198,12 @@ resource "aws_s3_bucket_metric" "this" {
 }
 `
 		plan := runPlan(t, tofu, tfFile)
-		assertResourceChangeForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter", *plan.RawPlan(),
+		assertResourceChangeForAddress(t, "module.local.aws_s3_bucket_metric.this", filterKey, *plan.RawPlan(),
 			findSensitiveChange,
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"tags": map[string]interface{}{
+						tagsKey: map[string]interface{}{
 							"OtherKey": true,
 						},
 					},
@@ -211,7 +211,7 @@ resource "aws_s3_bucket_metric" "this" {
 			})
 
 		// The individual sub property is marked as secret
-		assertPlanForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter", plan, func(actual interface{}) {
+		assertPlanForAddress(t, "module.local.aws_s3_bucket_metric.this", filterKey, plan, func(actual interface{}) {
 			assert.False(t, resource.NewPropertyValue(actual).IsSecret())
 		})
 		assertPlanForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter[0].tags.OtherKey", plan,
@@ -261,17 +261,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 			findSensitiveChange,
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{map[string]interface{}{
-					"abort_incomplete_multipart_upload": []interface{}{},
-					"expiration":                        []interface{}{},
-					"filter": []interface{}{map[string]interface{}{
-						"and":    []interface{}{map[string]interface{}{"object_size_greater_than": true}},
-						"prefix": true,
-						"tag":    []interface{}{},
+					abortIncompleteMultipartUploadKey: []interface{}{},
+					expirationKey:                     []interface{}{},
+					filterKey: []interface{}{map[string]interface{}{
+						andKey:    []interface{}{map[string]interface{}{objectSizeGreaterThanKey: true}},
+						prefixKey: true,
+						tagKey:    []interface{}{},
 					}},
-					"id":                            true,
-					"noncurrent_version_expiration": []interface{}{},
-					"noncurrent_version_transition": []interface{}{},
-					"transition":                    true,
+					"id":                           true,
+					noncurrentVersionExpirationKey: []interface{}{},
+					noncurrentVersionTransitionKey: []interface{}{},
+					transitionKey:                  true,
 				}}).Equal(t, actual)
 			})
 

--- a/tests/schema_create_test.go
+++ b/tests/schema_create_test.go
@@ -32,6 +32,41 @@ import (
 	"github.com/pulumi/pulumi-terraform-module/pkg/tfsandbox"
 )
 
+const (
+	fullControlPermission                 = "FULL_CONTROL"
+	canonicalUserType                     = "CanonicalUser"
+	glacierStorageClass                   = "GLACIER"
+	abortIncompleteMultipartUploadKey     = "abort_incomplete_multipart_upload"
+	abortIncompleteMultipartUploadDaysKey = "abort_incomplete_multipart_upload_days"
+	andKey                                = "and"
+
+	expirationKey                  = "expiration"
+	transitionKey                  = "transition"
+	noncurrentVersionTransitionKey = "noncurrent_version_transition"
+	noncurrentVersionExpirationKey = "noncurrent_version_expiration"
+	objectSizeGreaterThanKey       = "object_size_greater_than"
+	deleteOnTerminationKey         = "delete_on_termination"
+	prefixKey                      = "prefix"
+	tagsKey                        = "tags"
+	tagsAllKey                     = "tags_all"
+	tagKey                         = "tag"
+	typeKey                        = "type"
+	uriKey                         = "uri"
+	permissionsKey                 = "permissions"
+	filterKey                      = "filter"
+	enabledKey                     = "enabled"
+	ruleIDVal                      = "rule_id"
+	volumeSizeKey                  = "volume_size"
+	volumeTypeKey                  = "volume_type"
+	volumeIDKey                    = "volume_id"
+	deviceNameKey                  = "device_name"
+	encryptedKey                   = "encrypted"
+	iopsKey                        = "iops"
+	kmsKeyIDKey                    = "kms_key_id"
+	snapshotIDKey                  = "snapshot_id"
+	throughputKey                  = "throughput"
+)
+
 // The purpose of this test is to see how the plan is generated for different schema types
 // and how we translate that plan to a resource.PropertyValue.
 func TestUnknownsInCreatePlanBySchemaType(t *testing.T) {
@@ -90,25 +125,25 @@ resource "aws_s3_bucket" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"abort_incomplete_multipart_upload_days": nil,
-						"enabled":                                true,
-						"expiration":                             []interface{}{},
-						"id":                                     "rule_id",
-						"noncurrent_version_expiration":          []interface{}{},
-						"noncurrent_version_transition":          []interface{}{},
-						"prefix":                                 "/abc",
-						"tags":                                   nil,
-						"transition":                             []interface{}{},
+						abortIncompleteMultipartUploadDaysKey: nil,
+						enabledKey:                            true,
+						expirationKey:                         []interface{}{},
+						"id":                                  ruleIDVal,
+						noncurrentVersionExpirationKey:        []interface{}{},
+						noncurrentVersionTransitionKey:        []interface{}{},
+						prefixKey:                             "/abc",
+						tagsKey:                               nil,
+						transitionKey:                         []interface{}{},
 					},
 					map[string]interface{}{
-						"abort_incomplete_multipart_upload_days": nil,
-						"enabled":                                true,
-						"expiration":                             []interface{}{},
-						"noncurrent_version_expiration":          []interface{}{},
-						"noncurrent_version_transition":          []interface{}{},
-						"prefix":                                 nil,
-						"tags":                                   nil,
-						"transition":                             []interface{}{},
+						abortIncompleteMultipartUploadDaysKey: nil,
+						enabledKey:                            true,
+						expirationKey:                         []interface{}{},
+						noncurrentVersionExpirationKey:        []interface{}{},
+						noncurrentVersionTransitionKey:        []interface{}{},
+						prefixKey:                             nil,
+						tagsKey:                               nil,
+						transitionKey:                         []interface{}{},
 					},
 				}).Equal(t, actual)
 			})
@@ -117,17 +152,17 @@ resource "aws_s3_bucket" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"expiration":                    []interface{}{},
-						"noncurrent_version_expiration": []interface{}{},
-						"noncurrent_version_transition": []interface{}{},
-						"transition":                    []interface{}{},
+						expirationKey:                  []interface{}{},
+						noncurrentVersionExpirationKey: []interface{}{},
+						noncurrentVersionTransitionKey: []interface{}{},
+						transitionKey:                  []interface{}{},
 					},
 					map[string]interface{}{
-						"expiration":                    []interface{}{},
-						"noncurrent_version_expiration": []interface{}{},
-						"noncurrent_version_transition": []interface{}{},
-						"id":                            true,
-						"transition":                    []interface{}{},
+						expirationKey:                  []interface{}{},
+						noncurrentVersionExpirationKey: []interface{}{},
+						noncurrentVersionTransitionKey: []interface{}{},
+						"id":                           true,
+						transitionKey:                  []interface{}{},
 					},
 				}).Equal(t, actual)
 			})
@@ -135,27 +170,27 @@ resource "aws_s3_bucket" "this" {
 			autogold.Expect([]resource.PropertyValue{
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"enabled":                                resource.NewBoolProperty(true),
-						"id":                                     resource.NewStringProperty("rule_id"),
-						"prefix":                                 resource.NewStringProperty("/abc"),
-						"abort_incomplete_multipart_upload_days": resource.NewNullProperty(),
-						"expiration":                             resource.NewArrayProperty([]resource.PropertyValue{}),
-						"noncurrent_version_expiration":          resource.NewArrayProperty([]resource.PropertyValue{}),
-						"noncurrent_version_transition":          resource.NewArrayProperty([]resource.PropertyValue{}),
-						"tags":                                   resource.NewNullProperty(),
-						"transition":                             resource.NewArrayProperty([]resource.PropertyValue{}),
+						enabledKey:                            resource.NewBoolProperty(true),
+						"id":                                  resource.NewStringProperty(ruleIDVal),
+						prefixKey:                             resource.NewStringProperty("/abc"),
+						abortIncompleteMultipartUploadDaysKey: resource.NewNullProperty(),
+						expirationKey:                         resource.NewArrayProperty([]resource.PropertyValue{}),
+						noncurrentVersionExpirationKey:        resource.NewArrayProperty([]resource.PropertyValue{}),
+						noncurrentVersionTransitionKey:        resource.NewArrayProperty([]resource.PropertyValue{}),
+						tagsKey:                               resource.NewNullProperty(),
+						transitionKey:                         resource.NewArrayProperty([]resource.PropertyValue{}),
 					}),
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"enabled":                                resource.NewBoolProperty(true),
-						"id":                                     resource.MakeComputed(resource.NewStringProperty("")),
-						"prefix":                                 resource.NewNullProperty(),
-						"abort_incomplete_multipart_upload_days": resource.NewNullProperty(),
-						"expiration":                             resource.NewArrayProperty([]resource.PropertyValue{}),
-						"noncurrent_version_expiration":          resource.NewArrayProperty([]resource.PropertyValue{}),
-						"noncurrent_version_transition":          resource.NewArrayProperty([]resource.PropertyValue{}),
-						"tags":                                   resource.NewNullProperty(),
-						"transition":                             resource.NewArrayProperty([]resource.PropertyValue{}),
+						enabledKey:                            resource.NewBoolProperty(true),
+						"id":                                  resource.MakeComputed(resource.NewStringProperty("")),
+						prefixKey:                             resource.NewNullProperty(),
+						abortIncompleteMultipartUploadDaysKey: resource.NewNullProperty(),
+						expirationKey:                         resource.NewArrayProperty([]resource.PropertyValue{}),
+						noncurrentVersionExpirationKey:        resource.NewArrayProperty([]resource.PropertyValue{}),
+						noncurrentVersionTransitionKey:        resource.NewArrayProperty([]resource.PropertyValue{}),
+						tagsKey:                               resource.NewNullProperty(),
+						transitionKey:                         resource.NewArrayProperty([]resource.PropertyValue{}),
 					}),
 			}).Equal(t, actual)
 		})
@@ -185,9 +220,9 @@ resource "aws_s3_bucket" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"permissions": []interface{}{"FULL_CONTROL"},
-						"type":        "CanonicalUser",
-						"uri":         "",
+						permissionsKey: []interface{}{fullControlPermission},
+						typeKey:        canonicalUserType,
+						uriKey:         "",
 					},
 				}).Equal(t, actual)
 			})
@@ -197,7 +232,7 @@ resource "aws_s3_bucket" "this" {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
 						"id": true,
-						"permissions": []interface{}{
+						permissionsKey: []interface{}{
 							false,
 						},
 					},
@@ -208,10 +243,11 @@ resource "aws_s3_bucket" "this" {
 			autogold.Expect([]resource.PropertyValue{
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"id":          resource.MakeComputed(resource.NewStringProperty("")),
-						"permissions": resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("FULL_CONTROL")}),
-						"type":        resource.NewStringProperty("CanonicalUser"),
-						"uri":         resource.NewStringProperty(""),
+						"id": resource.MakeComputed(resource.NewStringProperty("")),
+						permissionsKey: resource.NewArrayProperty(
+							[]resource.PropertyValue{resource.NewStringProperty(fullControlPermission)}),
+						typeKey: resource.NewStringProperty(canonicalUserType),
+						uriKey:  resource.NewStringProperty(""),
 					}),
 			}).Equal(t, actual)
 		})
@@ -242,10 +278,10 @@ resource "aws_instance" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"delete_on_termination": true,
-						"tags":                  nil,
-						"volume_size":           json.Number("8"),
-						"volume_type":           "gp2",
+						deleteOnTerminationKey: true,
+						tagsKey:                nil,
+						volumeSizeKey:          json.Number("8"),
+						volumeTypeKey:          "gp2",
 					},
 				}).Equal(t, actual)
 			})
@@ -254,14 +290,14 @@ resource "aws_instance" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"device_name": true,
-						"encrypted":   true,
-						"iops":        true,
-						"kms_key_id":  true,
-						"snapshot_id": true,
-						"tags_all":    true,
-						"throughput":  true,
-						"volume_id":   true,
+						deviceNameKey: true,
+						encryptedKey:  true,
+						iopsKey:       true,
+						kmsKeyIDKey:   true,
+						snapshotIDKey: true,
+						tagsAllKey:    true,
+						throughputKey: true,
+						volumeIDKey:   true,
 					},
 				}).Equal(t, actual)
 			})
@@ -270,18 +306,18 @@ resource "aws_instance" "this" {
 			autogold.Expect([]resource.PropertyValue{
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"delete_on_termination": resource.NewBoolProperty(true),
-						"device_name":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags":                  resource.NewNullProperty(),
-						"volume_size":           resource.NewNumberProperty(8),
-						"volume_type":           resource.NewStringProperty("gp2"),
-						"encrypted":             resource.MakeComputed(resource.NewStringProperty("")),
-						"iops":                  resource.MakeComputed(resource.NewStringProperty("")),
-						"kms_key_id":            resource.MakeComputed(resource.NewStringProperty("")),
-						"snapshot_id":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags_all":              resource.MakeComputed(resource.NewStringProperty("")),
-						"throughput":            resource.MakeComputed(resource.NewStringProperty("")),
-						"volume_id":             resource.MakeComputed(resource.NewStringProperty("")),
+						deleteOnTerminationKey: resource.NewBoolProperty(true),
+						deviceNameKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsKey:                resource.NewNullProperty(),
+						volumeSizeKey:          resource.NewNumberProperty(8),
+						volumeTypeKey:          resource.NewStringProperty("gp2"),
+						encryptedKey:           resource.MakeComputed(resource.NewStringProperty("")),
+						iopsKey:                resource.MakeComputed(resource.NewStringProperty("")),
+						kmsKeyIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
+						snapshotIDKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsAllKey:             resource.MakeComputed(resource.NewStringProperty("")),
+						throughputKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						volumeIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
 					}),
 			}).Equal(t, actual)
 		})
@@ -328,15 +364,15 @@ resource "aws_instance" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"delete_on_termination": true,
-						"tags":                  nil,
-						"volume_size":           json.Number("7"),
-						"volume_type":           "gp3",
+						deleteOnTerminationKey: true,
+						tagsKey:                nil,
+						volumeSizeKey:          json.Number("7"),
+						volumeTypeKey:          "gp3",
 					},
 					map[string]interface{}{
-						"delete_on_termination": true,
-						"tags":                  nil,
-						"volume_size":           json.Number("8"),
+						deleteOnTerminationKey: true,
+						tagsKey:                nil,
+						volumeSizeKey:          json.Number("8"),
 					},
 				}).Equal(t, actual)
 			})
@@ -345,25 +381,25 @@ resource "aws_instance" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"device_name": true,
-						"encrypted":   true,
-						"iops":        true,
-						"kms_key_id":  true,
-						"snapshot_id": true,
-						"tags_all":    true,
-						"throughput":  true,
-						"volume_id":   true,
+						deviceNameKey: true,
+						encryptedKey:  true,
+						iopsKey:       true,
+						kmsKeyIDKey:   true,
+						snapshotIDKey: true,
+						tagsAllKey:    true,
+						throughputKey: true,
+						volumeIDKey:   true,
 					},
 					map[string]interface{}{
-						"device_name": true,
-						"volume_type": true,
-						"encrypted":   true,
-						"iops":        true,
-						"kms_key_id":  true,
-						"snapshot_id": true,
-						"tags_all":    true,
-						"throughput":  true,
-						"volume_id":   true,
+						deviceNameKey: true,
+						volumeTypeKey: true,
+						encryptedKey:  true,
+						iopsKey:       true,
+						kmsKeyIDKey:   true,
+						snapshotIDKey: true,
+						tagsAllKey:    true,
+						throughputKey: true,
+						volumeIDKey:   true,
 					},
 				}).Equal(t, actual)
 			})
@@ -372,33 +408,33 @@ resource "aws_instance" "this" {
 			autogold.Expect([]resource.PropertyValue{
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"delete_on_termination": resource.NewBoolProperty(true),
-						"device_name":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags":                  resource.NewNullProperty(),
-						"volume_size":           resource.NewNumberProperty(7),
-						"volume_type":           resource.NewStringProperty("gp3"),
-						"encrypted":             resource.MakeComputed(resource.NewStringProperty("")),
-						"iops":                  resource.MakeComputed(resource.NewStringProperty("")),
-						"kms_key_id":            resource.MakeComputed(resource.NewStringProperty("")),
-						"snapshot_id":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags_all":              resource.MakeComputed(resource.NewStringProperty("")),
-						"throughput":            resource.MakeComputed(resource.NewStringProperty("")),
-						"volume_id":             resource.MakeComputed(resource.NewStringProperty("")),
+						deleteOnTerminationKey: resource.NewBoolProperty(true),
+						deviceNameKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsKey:                resource.NewNullProperty(),
+						volumeSizeKey:          resource.NewNumberProperty(7),
+						volumeTypeKey:          resource.NewStringProperty("gp3"),
+						encryptedKey:           resource.MakeComputed(resource.NewStringProperty("")),
+						iopsKey:                resource.MakeComputed(resource.NewStringProperty("")),
+						kmsKeyIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
+						snapshotIDKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsAllKey:             resource.MakeComputed(resource.NewStringProperty("")),
+						throughputKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						volumeIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
 					}),
 				resource.NewObjectProperty(
 					resource.PropertyMap{
-						"delete_on_termination": resource.NewBoolProperty(true),
-						"device_name":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags":                  resource.NewNullProperty(),
-						"volume_size":           resource.NewNumberProperty(8),
-						"volume_type":           resource.MakeComputed(resource.NewStringProperty("")),
-						"encrypted":             resource.MakeComputed(resource.NewStringProperty("")),
-						"iops":                  resource.MakeComputed(resource.NewStringProperty("")),
-						"kms_key_id":            resource.MakeComputed(resource.NewStringProperty("")),
-						"snapshot_id":           resource.MakeComputed(resource.NewStringProperty("")),
-						"tags_all":              resource.MakeComputed(resource.NewStringProperty("")),
-						"throughput":            resource.MakeComputed(resource.NewStringProperty("")),
-						"volume_id":             resource.MakeComputed(resource.NewStringProperty("")),
+						deleteOnTerminationKey: resource.NewBoolProperty(true),
+						deviceNameKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsKey:                resource.NewNullProperty(),
+						volumeSizeKey:          resource.NewNumberProperty(8),
+						volumeTypeKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						encryptedKey:           resource.MakeComputed(resource.NewStringProperty("")),
+						iopsKey:                resource.MakeComputed(resource.NewStringProperty("")),
+						kmsKeyIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
+						snapshotIDKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						tagsAllKey:             resource.MakeComputed(resource.NewStringProperty("")),
+						throughputKey:          resource.MakeComputed(resource.NewStringProperty("")),
+						volumeIDKey:            resource.MakeComputed(resource.NewStringProperty("")),
 					}),
 			}).Equal(t, actual)
 		})
@@ -428,33 +464,33 @@ resource "aws_s3_bucket_metric" "this" {
 }
 `
 		plan := runPlan(t, tofu, tfFile)
-		assertAttributeValuesForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter", *plan.RawPlan(),
+		assertAttributeValuesForAddress(t, "module.local.aws_s3_bucket_metric.this", filterKey, *plan.RawPlan(),
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
 						"access_point": nil,
-						"prefix":       nil,
+						prefixKey:      nil,
 					},
 				}).Equal(t, actual)
 			})
-		assertResourceChangeForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter", *plan.RawPlan(),
+		assertResourceChangeForAddress(t, "module.local.aws_s3_bucket_metric.this", filterKey, *plan.RawPlan(),
 			findUnknownChange,
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{
 					map[string]interface{}{
-						"tags": true,
+						tagsKey: true,
 					},
 				}).Equal(t, actual)
 			})
 
-		assertPlanForAddress(t, "module.local.aws_s3_bucket_metric.this", "filter", plan,
+		assertPlanForAddress(t, "module.local.aws_s3_bucket_metric.this", filterKey, plan,
 			func(actual interface{}) {
 				autogold.Expect([]resource.PropertyValue{
 					resource.NewObjectProperty(
 						resource.PropertyMap{
-							"tags":         resource.MakeComputed(resource.NewStringProperty("")),
+							tagsKey:        resource.MakeComputed(resource.NewStringProperty("")),
 							"access_point": resource.NewNullProperty(),
-							"prefix":       resource.NewNullProperty(),
+							prefixKey:      resource.NewNullProperty(),
 						}),
 				}).Equal(t, actual)
 			})
@@ -539,35 +575,35 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 		assertAttributeValuesForAddress(t, "module.local.aws_s3_bucket_lifecycle_configuration.this", "rule", *plan.RawPlan(),
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{map[string]interface{}{
-					"abort_incomplete_multipart_upload": []interface{}{},
-					"expiration":                        []interface{}{},
-					"filter": []interface{}{map[string]interface{}{
-						"and": []interface{}{map[string]interface{}{
-							"object_size_greater_than": json.Number("200"),
-							"object_size_less_than":    json.Number("0"),
-							"prefix":                   "",
-							"tags":                     nil,
+					abortIncompleteMultipartUploadKey: []interface{}{},
+					expirationKey:                     []interface{}{},
+					filterKey: []interface{}{map[string]interface{}{
+						andKey: []interface{}{map[string]interface{}{
+							objectSizeGreaterThanKey: json.Number("200"),
+							"object_size_less_than":  json.Number("0"),
+							prefixKey:                "",
+							tagsKey:                  nil,
 						}},
-						"object_size_greater_than": nil,
-						"object_size_less_than":    nil,
-						"prefix":                   "test",
-						"tag":                      []interface{}{},
+						objectSizeGreaterThanKey: nil,
+						"object_size_less_than":  nil,
+						prefixKey:                "test",
+						tagKey:                   []interface{}{},
 					}},
-					"id":                            "rule_id",
-					"noncurrent_version_expiration": []interface{}{},
-					"noncurrent_version_transition": []interface{}{},
-					"prefix":                        "",
-					"status":                        "Enabled",
-					"transition": []interface{}{
+					"id":                           ruleIDVal,
+					noncurrentVersionExpirationKey: []interface{}{},
+					noncurrentVersionTransitionKey: []interface{}{},
+					prefixKey:                      "",
+					"status":                       "Enabled",
+					transitionKey: []interface{}{
 						map[string]interface{}{
 							"date":          nil,
 							"days":          json.Number("0"),
-							"storage_class": "GLACIER",
+							"storage_class": glacierStorageClass,
 						},
 						map[string]interface{}{
 							"date":          nil,
 							"days":          json.Number("30"),
-							"storage_class": "GLACIER",
+							"storage_class": glacierStorageClass,
 						},
 					},
 				}}).Equal(t, actual)
@@ -577,15 +613,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 			findUnknownChange,
 			func(actual interface{}) {
 				autogold.Expect([]interface{}{map[string]interface{}{
-					"abort_incomplete_multipart_upload": []interface{}{},
-					"expiration":                        []interface{}{},
-					"filter": []interface{}{map[string]interface{}{
-						"and": []interface{}{map[string]interface{}{}},
-						"tag": []interface{}{},
+					abortIncompleteMultipartUploadKey: []interface{}{},
+					expirationKey:                     []interface{}{},
+					filterKey: []interface{}{map[string]interface{}{
+						andKey: []interface{}{map[string]interface{}{}},
+						tagKey: []interface{}{},
 					}},
-					"noncurrent_version_expiration": []interface{}{},
-					"noncurrent_version_transition": []interface{}{},
-					"transition": []interface{}{
+					noncurrentVersionExpirationKey: []interface{}{},
+					noncurrentVersionTransitionKey: []interface{}{},
+					transitionKey: []interface{}{
 						map[string]interface{}{},
 						map[string]interface{}{},
 					},
@@ -596,45 +632,45 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 			func(actual interface{}) {
 				autogold.Expect([]resource.PropertyValue{{
 					V: resource.PropertyMap{
-						resource.PropertyKey("abort_incomplete_multipart_upload"): resource.PropertyValue{
+						resource.PropertyKey(abortIncompleteMultipartUploadKey): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("expiration"): resource.PropertyValue{V: []resource.PropertyValue{}},
-						resource.PropertyKey("filter"): resource.PropertyValue{V: []resource.PropertyValue{{
+						resource.PropertyKey(expirationKey): resource.PropertyValue{V: []resource.PropertyValue{}},
+						resource.PropertyKey(filterKey): resource.PropertyValue{V: []resource.PropertyValue{{
 							V: resource.PropertyMap{
-								resource.PropertyKey("and"): resource.PropertyValue{
+								resource.PropertyKey(andKey): resource.PropertyValue{
 									V: []resource.PropertyValue{{
 										V: resource.PropertyMap{
-											resource.PropertyKey("object_size_greater_than"): resource.PropertyValue{
+											resource.PropertyKey(objectSizeGreaterThanKey): resource.PropertyValue{
 												V: 200,
 											},
 											resource.PropertyKey("object_size_less_than"): resource.PropertyValue{V: 0},
-											resource.PropertyKey("prefix"):                resource.PropertyValue{V: ""},
-											resource.PropertyKey("tags"):                  resource.PropertyValue{},
+											resource.PropertyKey(prefixKey):               resource.PropertyValue{V: ""},
+											resource.PropertyKey(tagsKey):                 resource.PropertyValue{},
 										},
 									}},
 								},
-								resource.PropertyKey("object_size_greater_than"): resource.PropertyValue{},
-								resource.PropertyKey("object_size_less_than"):    resource.PropertyValue{},
-								resource.PropertyKey("prefix"):                   resource.PropertyValue{V: "test"},
-								resource.PropertyKey("tag"):                      resource.PropertyValue{V: []resource.PropertyValue{}},
+								resource.PropertyKey(objectSizeGreaterThanKey): resource.PropertyValue{},
+								resource.PropertyKey("object_size_less_than"):  resource.PropertyValue{},
+								resource.PropertyKey(prefixKey):                resource.PropertyValue{V: "test"},
+								resource.PropertyKey(tagKey):                   resource.PropertyValue{V: []resource.PropertyValue{}},
 							},
 						}}},
-						resource.PropertyKey("id"):                            resource.PropertyValue{V: "rule_id"},
-						resource.PropertyKey("noncurrent_version_expiration"): resource.PropertyValue{V: []resource.PropertyValue{}},
-						resource.PropertyKey("noncurrent_version_transition"): resource.PropertyValue{V: []resource.PropertyValue{}},
-						resource.PropertyKey("prefix"):                        resource.PropertyValue{V: ""},
-						resource.PropertyKey("status"):                        resource.PropertyValue{V: "Enabled"},
-						resource.PropertyKey("transition"): resource.PropertyValue{V: []resource.PropertyValue{
+						resource.PropertyKey("id"):                           resource.PropertyValue{V: ruleIDVal},
+						resource.PropertyKey(noncurrentVersionExpirationKey): resource.PropertyValue{V: []resource.PropertyValue{}},
+						resource.PropertyKey(noncurrentVersionTransitionKey): resource.PropertyValue{V: []resource.PropertyValue{}},
+						resource.PropertyKey(prefixKey):                      resource.PropertyValue{V: ""},
+						resource.PropertyKey("status"):                       resource.PropertyValue{V: "Enabled"},
+						resource.PropertyKey(transitionKey): resource.PropertyValue{V: []resource.PropertyValue{
 							{V: resource.PropertyMap{
 								resource.PropertyKey("date"):          resource.PropertyValue{},
 								resource.PropertyKey("days"):          resource.PropertyValue{V: 0},
-								resource.PropertyKey("storage_class"): resource.PropertyValue{V: "GLACIER"},
+								resource.PropertyKey("storage_class"): resource.PropertyValue{V: glacierStorageClass},
 							}},
 							{V: resource.PropertyMap{
 								resource.PropertyKey("date"):          resource.PropertyValue{},
 								resource.PropertyKey("days"):          resource.PropertyValue{V: 30},
-								resource.PropertyKey("storage_class"): resource.PropertyValue{V: "GLACIER"},
+								resource.PropertyKey("storage_class"): resource.PropertyValue{V: glacierStorageClass},
 							}},
 						}},
 					},


### PR DESCRIPTION
The ci-mgmt workflow update bumps golangci-lint to 2.12.2, which enables stricter `goconst`/`gosec` checks. This hoists repeated string literals into named constants and adds line-scoped `//nolint:gosec` annotations (with reasons) to test-controlled filesystem paths. Scope is the `lint` job only. Verified locally with golangci-lint 2.12.2 (uncapped) reporting 0 issues.

Part of #890
Part of pulumi/home#4817
