### PR TITLE
Fix awslambdamod test source_path to resolve from __dirname

### DIFF
--- a/tests/testdata/programs/ts/awslambdamod/index.ts
+++ b/tests/testdata/programs/ts/awslambdamod/index.ts
@@ -8,7 +8,7 @@ const prefix = config.get('prefix') ?? pulumi.getStack();
 
 const testlambda = new lambda.Module("test-lambda", {
     function_name: `${prefix}-testlambda`,
-    source_path:  path.join(process.env["PWD"], "/src/app.ts"),
+    source_path:  path.join(__dirname, "src/app.ts"),
     runtime:  "nodejs22.x",
     handler: "app.handler",
 })


### PR DESCRIPTION
The `awslambdamod` acceptance fixture built its Lambda `source_path` from `process.env["PWD"]`, which reflects the directory `go test` was launched from (`tests/`), not the fixture's own directory. Under the test harness this resolved to `.../tests/src/app.ts`, so the Lambda module's `data.external.archive_prepare` packaging step could not locate the source and failed `tofu plan` with `Could not locate source_path`. Switching to `__dirname` (as the `lambdamod-memory-diff` fixture already does) resolves the path from the file's own location regardless of harness CWD.

Verified by the `run-acceptance-tests` `test (8,4)`/`test (8,5)` shards, which previously failed on exactly this error.


Part of #895
