### PR TITLE
Deprecate Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This provider supports running Terraform Modules directly in Pulumi.
 
+> [!IMPORTANT]
+> This Package is deprecated. To use Terraform modules in Pulumi, we recommend using the [Any Terraform Module](https://www.pulumi.com/registry/packages/hcl/) provider.
+
 ## Usage
 
 To get started, run this in the context of a Pulumi program:


### PR DESCRIPTION
## Context

As part of the shift to a native HCL execution path, the [TF Modules in Pulumi Experience epic](https://github.com/pulumi/home/issues/4803) explicitly calls for formally deprecating `pulumi-terraform-module`, stopping new users from being directed to it, and documenting migration paths to `pulumi-hcl`.

## Overview

Marks the package as deprecated in the README, directing users to the [Any Terraform Module](https://www.pulumi.com/registry/packages/hcl/) provider instead.